### PR TITLE
[Fix] Stabilize core gameplay systems

### DIFF
--- a/Assets/Scripts/Enemy/BT/Actions/CustomPatrolAction.cs
+++ b/Assets/Scripts/Enemy/BT/Actions/CustomPatrolAction.cs
@@ -31,13 +31,13 @@ public partial class CustomPatrolAction : Action
 
     protected override Status OnStart()
     {
-        if (Agent.Value == null)
+        if (Agent == null || Agent.Value == null)
         {
             LogFailure("No agent assigned.");
             return Status.Failure;
         }
 
-        if (Waypoints.Value == null || Waypoints.Value.Count == 0)
+        if (HasValidWaypoint() == false)
         {
             LogFailure("No waypoints to patrol assigned.");
             return Status.Failure;
@@ -48,13 +48,12 @@ public partial class CustomPatrolAction : Action
         m_Waiting = false;
         m_WaypointWaitTimer = 0.0f;
 
-        MoveToNextWaypoint();
-        return Status.Running;
+        return MoveToNextWaypoint() ? Status.Running : Status.Failure;
     }
 
     protected override Status OnUpdate()
     {
-        if (Agent.Value == null || Waypoints.Value == null)
+        if (Agent == null || Agent.Value == null || HasValidWaypoint() == false)
         {
             return Status.Failure;
         }
@@ -69,7 +68,10 @@ public partial class CustomPatrolAction : Action
             {
                 m_WaypointWaitTimer = 0f;
                 m_Waiting = false;
-                MoveToNextWaypoint();
+                if (MoveToNextWaypoint() == false)
+                {
+                    return Status.Failure;
+                }
             }
         }
         else
@@ -114,6 +116,12 @@ public partial class CustomPatrolAction : Action
 
     protected override void OnDeserialize()
     {
+        if (Agent == null || Agent.Value == null)
+        {
+            m_NavMeshAgent = null;
+            return;
+        }
+
         // If using a navigation mesh, we need to reset default value before Initialize.
         m_NavMeshAgent = Agent.Value.GetComponentInChildren<NavMeshAgent>();
         if (m_NavMeshAgent != null)
@@ -167,15 +175,42 @@ public partial class CustomPatrolAction : Action
         return Vector3.Distance(agentPosition, targetPosition);
     }
 
-    private void MoveToNextWaypoint()
+    private bool MoveToNextWaypoint()
     {
-        m_CurrentPatrolPoint = (m_CurrentPatrolPoint + 1) % Waypoints.Value.Count;
+        if (Waypoints == null || Waypoints.Value == null || Waypoints.Value.Count == 0) return false;
 
-        m_CurrentTarget = Waypoints.Value[m_CurrentPatrolPoint].transform.position;
-        if (m_NavMeshAgent != null && m_NavMeshAgent.isOnNavMesh)
+        for (var i = 0; i < Waypoints.Value.Count; i++)
         {
-            m_NavMeshAgent.SetDestination(m_CurrentTarget);
+            m_CurrentPatrolPoint = (m_CurrentPatrolPoint + 1) % Waypoints.Value.Count;
+            var waypoint = Waypoints.Value[m_CurrentPatrolPoint];
+            if (waypoint == null || waypoint.activeInHierarchy == false) continue;
+
+            m_CurrentTarget = waypoint.transform.position;
+            if (m_NavMeshAgent != null && m_NavMeshAgent.isOnNavMesh)
+            {
+                m_NavMeshAgent.SetDestination(m_CurrentTarget);
+            }
+
+            return true;
         }
+
+        return false;
+    }
+
+    private bool HasValidWaypoint()
+    {
+        if (Waypoints == null || Waypoints.Value == null) return false;
+
+        for (var i = 0; i < Waypoints.Value.Count; i++)
+        {
+            var waypoint = Waypoints.Value[i];
+            if (waypoint != null && waypoint.activeInHierarchy)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void UpdateAnimatorSpeed(float explicitSpeed = -1f)

--- a/Assets/Scripts/Enemy/BT/Actions/ListCountCondition.cs
+++ b/Assets/Scripts/Enemy/BT/Actions/ListCountCondition.cs
@@ -16,6 +16,15 @@ public partial class ListCountCondition : Condition
     {
         if (PatrolPoints == null || ComparisonIntValue == null) return false;
         if (PatrolPoints.Value == null || ComparisonIntValue.Type != typeof(int)) return false;
-        return ConditionUtils.Evaluate(PatrolPoints.Value.Count, Operator, ComparisonIntValue);
+        var validCount = 0;
+        foreach (var patrolPoint in PatrolPoints.Value)
+        {
+            if (patrolPoint != null && patrolPoint.activeInHierarchy)
+            {
+                validCount++;
+            }
+        }
+
+        return ConditionUtils.Evaluate(validCount, Operator, ComparisonIntValue);
     }
 }

--- a/Assets/Scripts/Enemy/BT/Actions/PatrolPathFinderAction.cs
+++ b/Assets/Scripts/Enemy/BT/Actions/PatrolPathFinderAction.cs
@@ -26,8 +26,7 @@ public partial class PatrolPathFinderAction : Action
 
     protected override Status OnStart()
     {
-        Init();
-        return Status.Running;
+        return Init() ? Status.Running : Status.Failure;
     }
 
     protected override Status OnUpdate()
@@ -59,9 +58,22 @@ public partial class PatrolPathFinderAction : Action
         else return false;
     }
 
-    public void Init()
+    public bool Init()
     {
+        if (Agent == null || Agent.Value == null)
+        {
+            LogFailure("No agent assigned.");
+            return false;
+        }
+
+        if (PatrolPoints == null)
+        {
+            LogFailure("No patrol point variable assigned.");
+            return false;
+        }
+
         m_navAgent = Agent.Value.GetComponentInChildren<NavMeshAgent>();
+        PatrolPoints.Value = new List<GameObject>();
         m_patrolPool = new();
         var obj = new GameObject("point").transform;
         obj.transform.parent = Agent.Value.transform;
@@ -71,6 +83,9 @@ public partial class PatrolPathFinderAction : Action
 
         if (InGameLoop.Instance != null)
             Target.Value = InGameLoop.Instance.Player.gameObject;
+
+        m_Timer = 0f;
+        return true;
     }
 
     public void Setup(List<GameObject> patrolPoints)
@@ -97,6 +112,8 @@ public partial class PatrolPathFinderAction : Action
 
     public void PathFind()
     {
+        if (Agent == null || Agent.Value == null || m_navAgent == null || m_patrolPool == null) return;
+
         var patrolPoints = new List<GameObject>();
         // Check if Agent is currently placed on valid NavMesh Path
         if (m_navAgent != null && IsActiveNavAgent == true && m_navAgent.isOnNavMesh)

--- a/Assets/Scripts/Enemy/BT/Actions/PatrolPathFinderAction.cs
+++ b/Assets/Scripts/Enemy/BT/Actions/PatrolPathFinderAction.cs
@@ -73,13 +73,18 @@ public partial class PatrolPathFinderAction : Action
         }
 
         m_navAgent = Agent.Value.GetComponentInChildren<NavMeshAgent>();
+        ReturnPatrolPoints();
         PatrolPoints.Value = new List<GameObject>();
-        m_patrolPool = new();
-        var obj = new GameObject("point").transform;
-        obj.transform.parent = Agent.Value.transform;
-        m_patrolPool.poolObj = obj;
-        m_patrolPool.InitSize = PatrolPointCount;
-        m_patrolPool.Init(Agent.Value.transform);
+        if (m_patrolPool == null)
+        {
+            m_patrolPool = new ObjectPool<Transform>();
+            var template = new GameObject("Patrol Point Template").transform;
+            template.SetParent(Agent.Value.transform, false);
+            template.gameObject.SetActive(false);
+            m_patrolPool.poolObj = template;
+            m_patrolPool.InitSize = PatrolPointCount;
+            m_patrolPool.Init(Agent.Value.transform);
+        }
 
         if (InGameLoop.Instance != null)
             Target.Value = InGameLoop.Instance.Player.gameObject;
@@ -114,6 +119,7 @@ public partial class PatrolPathFinderAction : Action
     {
         if (Agent == null || Agent.Value == null || m_navAgent == null || m_patrolPool == null) return;
 
+        ReturnPatrolPoints();
         var patrolPoints = new List<GameObject>();
         // Check if Agent is currently placed on valid NavMesh Path
         if (m_navAgent != null && IsActiveNavAgent == true && m_navAgent.isOnNavMesh)
@@ -168,6 +174,21 @@ public partial class PatrolPathFinderAction : Action
                 patrolPoints.Clear();
             }
         }
+    }
+
+    private void ReturnPatrolPoints()
+    {
+        if (m_patrolPool == null || PatrolPoints?.Value == null) return;
+
+        foreach (var patrolPoint in PatrolPoints.Value)
+        {
+            if (patrolPoint != null && patrolPoint.activeSelf)
+            {
+                m_patrolPool.ReturnObject(patrolPoint.transform);
+            }
+        }
+
+        PatrolPoints.Value.Clear();
     }
 }
 

--- a/Assets/Scripts/Enemy/EnemyAI.cs
+++ b/Assets/Scripts/Enemy/EnemyAI.cs
@@ -15,11 +15,18 @@ public class EnemyAI : MonoBehaviour
 
     private void OnEnable()
     {
-        EnsureNavAgentReady();
+        if (EnsureNavAgentReady() == false)
+        {
+            if (BTAgent != null) BTAgent.enabled = false;
+            return;
+        }
 
-        BTAgent.enabled = true;
-        BTAgent.Init();
-        BTAgent.Restart();
+        if (BTAgent != null)
+        {
+            BTAgent.enabled = true;
+            BTAgent.Init();
+            BTAgent.Restart();
+        }
 
         if (NavAgent != null)
             NavAgent.updateRotation = false;
@@ -27,7 +34,7 @@ public class EnemyAI : MonoBehaviour
 
     private void OnDisable()
     {
-        BTAgent.enabled = false;
+        if (BTAgent != null) BTAgent.enabled = false;
         if (NavAgent != null) NavAgent.enabled = false;
     }
 
@@ -37,10 +44,7 @@ public class EnemyAI : MonoBehaviour
 
         NavAgent.updateRotation = false;
 
-        if (NavAgent.enabled == false)
-            NavAgent.enabled = true;
-
-        if (NavAgent.isOnNavMesh)
+        if (NavAgent.enabled && NavAgent.isOnNavMesh)
         {
             NavAgent.isStopped = false;
             return true;
@@ -53,6 +57,9 @@ public class EnemyAI : MonoBehaviour
         }
 
         transform.position = hit.position;
+        if (NavAgent.enabled == false)
+            NavAgent.enabled = true;
+
         NavAgent.Warp(hit.position);
         NavAgent.isStopped = false;
         return true;

--- a/Assets/Scripts/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Enemy/EnemyController.cs
@@ -1,9 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.AI;
-using Unity.Properties;
-using UnityEditor;
 
 
 [RequireComponent(typeof(Rigidbody))]

--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -66,13 +66,14 @@ public class EnemySpawner : MonoBehaviour
             }
             var selectKey = filter[Random.Range(0, filter.Count)];
             var pool = m_allEnemys[selectKey];
-            var enemy = pool.GetObject();
+            var enemy = pool.GetObject(false);
             var trans = enemy.transform;
             trans.position = pos;
             trans.rotation = Quaternion.identity;
+            enemy.Target = m_inGameLoop.Player.gameObject;
+            enemy.gameObject.SetActive(true);
             if (enemy.enabled)
             {
-                enemy.Target = m_inGameLoop.Player.gameObject;
                 enemy.ChunkRefresh();
             }
         }
@@ -97,14 +98,15 @@ public class EnemySpawner : MonoBehaviour
         foreach (var k in filter)
         {
             var pool = m_allEnemys[k];
-            var enemy = pool.GetObject();
+            var enemy = pool.GetObject(false);
             var trans = enemy.transform;
             if (useBasePostion == false)
                 trans.position = spawnPos;
             trans.rotation = Quaternion.identity;
+            enemy.Target = m_inGameLoop.Player.gameObject;
+            enemy.gameObject.SetActive(true);
             if (enemy.enabled)
             {
-                enemy.Target = m_inGameLoop.Player.gameObject;
                 enemy.ChunkRefresh();
             }
         }

--- a/Assets/Scripts/Enemy/EnemyStat.cs
+++ b/Assets/Scripts/Enemy/EnemyStat.cs
@@ -32,6 +32,7 @@ public class EnemyStat : MonoBehaviour
     private Vector3 m_pendingHitDirection;
     private float m_pendingKnockBackForce;
     private Coroutine m_navRestoreRoutine;
+    private bool m_isStageSubscribed;
     private static readonly int KnockBackHash = Animator.StringToHash("KnockBack");
     private static readonly int StateHash = Animator.StringToHash("State");
 
@@ -41,6 +42,7 @@ public class EnemyStat : MonoBehaviour
         m_hasPendingDeath = false;
         m_isDead = false;
         m_navRestoreRoutine = null;
+        SubscribeStageLevel();
 
         if (Ctrl != null && Ctrl.AI != null && Ctrl.AI.NavAgent != null)
         {
@@ -48,6 +50,11 @@ public class EnemyStat : MonoBehaviour
             if (Ctrl.AI.NavAgent.enabled && Ctrl.AI.NavAgent.isOnNavMesh)
                 Ctrl.AI.NavAgent.isStopped = false;
         }
+    }
+
+    private void OnDisable()
+    {
+        UnsubscribeStageLevel();
     }
 
     private void Start()
@@ -64,18 +71,41 @@ public class EnemyStat : MonoBehaviour
             { StatType.Money, Money},
         };
 
-        if (InGameLoop.Instance != null)
-        {
-            InGameLoop.Instance.StageLevel.OnValueChanged += UpdateStat;
-            UpdateStat(InGameLoop.Instance.StageLevel.Value);
-        }
-        else UpdateStat(1);
+        SubscribeStageLevel();
+        if (m_isStageSubscribed == false)
+            UpdateStat(1);
     }
 
     public void UpdateStat(int newLevel)
     {
         if (newLevel > StatData.Count) return;
         StatData[newLevel - 1].SetStat(ref StatDic);
+    }
+
+    private void SubscribeStageLevel()
+    {
+        if (m_isStageSubscribed || StatDic == null ||
+            InGameLoop.Instance == null || InGameLoop.Instance.StageLevel == null)
+        {
+            return;
+        }
+
+        InGameLoop.Instance.StageLevel.OnValueChanged += UpdateStat;
+        m_isStageSubscribed = true;
+        UpdateStat(InGameLoop.Instance.StageLevel.Value);
+    }
+
+    private void UnsubscribeStageLevel()
+    {
+        if (m_isStageSubscribed == false || InGameLoop.Instance == null ||
+            InGameLoop.Instance.StageLevel == null)
+        {
+            m_isStageSubscribed = false;
+            return;
+        }
+
+        InGameLoop.Instance.StageLevel.OnValueChanged -= UpdateStat;
+        m_isStageSubscribed = false;
     }
 
     public void ApplyDamage(float damage, Vector3 attackerPos, float force)
@@ -346,11 +376,6 @@ public class EnemyStat : MonoBehaviour
         foreach (var item in StatDic.Values)
         {
             item.RemoveAllModifier();
-        }
-
-        if (InGameLoop.Instance != null)
-        {
-            InGameLoop.Instance.StageLevel.OnValueChanged -= UpdateStat;
         }
 
         Ctrl.Rigid.useGravity = false;

--- a/Assets/Scripts/Enemy/EnemyStat.cs
+++ b/Assets/Scripts/Enemy/EnemyStat.cs
@@ -293,6 +293,7 @@ public class EnemyStat : MonoBehaviour
         var renderers = Ctrl.GetComponentsInChildren<Renderer>();
         var originMaterials = new Dictionary<Renderer, Material[]>();
         var fadeMaterials = new List<Material>();
+        var runtimeMaterials = new HashSet<Material>();
         var originPosition = Ctrl.transform.position;
         foreach (var renderer in renderers)
         {
@@ -300,7 +301,10 @@ public class EnemyStat : MonoBehaviour
             var materials = renderer.materials;
             foreach (var mat in materials)
             {
-                if (mat != null && mat.HasProperty("_Color"))
+                if (mat == null) continue;
+
+                runtimeMaterials.Add(mat);
+                if (mat.HasProperty("_Color"))
                     fadeMaterials.Add(mat);
             }
         }
@@ -337,7 +341,7 @@ public class EnemyStat : MonoBehaviour
 
         yield return sequence.WaitForCompletion();
 
-        CleanupAfterDeath(cols, originMaterials, originPosition);
+        CleanupAfterDeath(cols, originMaterials, runtimeMaterials, originPosition);
     }
 
     private void StopNavigationForDeath()
@@ -371,7 +375,11 @@ public class EnemyStat : MonoBehaviour
         navAgent.Warp(transform.position);
     }
 
-    private void CleanupAfterDeath(Collider[] cols, Dictionary<Renderer, Material[]> originMaterials, Vector3 originPosition)
+    private void CleanupAfterDeath(
+        Collider[] cols,
+        Dictionary<Renderer, Material[]> originMaterials,
+        HashSet<Material> runtimeMaterials,
+        Vector3 originPosition)
     {
         foreach (var item in StatDic.Values)
         {
@@ -391,6 +399,12 @@ public class EnemyStat : MonoBehaviour
         {
             if (kvp.Key != null)
                 kvp.Key.sharedMaterials = kvp.Value;
+        }
+
+        foreach (var material in runtimeMaterials)
+        {
+            if (material != null)
+                Destroy(material);
         }
 
         if (InGameLoop.Instance != null && InGameLoop.Instance.EnemySpawner != null)

--- a/Assets/Scripts/Enemy/EnemyStat.cs
+++ b/Assets/Scripts/Enemy/EnemyStat.cs
@@ -352,20 +352,18 @@ public class EnemyStat : MonoBehaviour
             Ctrl.AI.BTAgent.enabled = false;
 
         var navAgent = Ctrl.AI.NavAgent;
-        if (navAgent.enabled == false)
-            navAgent.enabled = true;
-
-        if (navAgent.isOnNavMesh == false)
+        if (navAgent.enabled == false || navAgent.isOnNavMesh == false)
         {
-            if (NavMesh.SamplePosition(transform.position, out var hit, 2.0f, NavMesh.AllAreas))
+            if (NavMesh.SamplePosition(transform.position, out var hit, 2.0f, NavMesh.AllAreas) == false)
             {
-                transform.position = hit.position;
-                navAgent.Warp(hit.position);
-            }
-            else
-            {
+                navAgent.enabled = false;
                 return;
             }
+
+            navAgent.enabled = false;
+            transform.position = hit.position;
+            navAgent.enabled = true;
+            navAgent.Warp(hit.position);
         }
 
         navAgent.ResetPath();

--- a/Assets/Scripts/Manager/ChunkManager/BSPNode.cs
+++ b/Assets/Scripts/Manager/ChunkManager/BSPNode.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+癤퓎sing System.Collections.Generic;
 using UnityEngine;
 
 public class BSPNode
@@ -6,6 +6,7 @@ public class BSPNode
     public RectInt Area;
     public BSPNode Left, Right;
     public bool IsLeaf => Left == null && Right == null;
+
     private RectInt room;
     public RectInt Room => room;
 
@@ -21,73 +22,98 @@ public class BSPNode
         bool splitHorizontally;
 
         if (Area.width > Area.height && Area.width >= 2 * minSize)
+        {
             splitHorizontally = true;
+        }
         else if (Area.height >= 2 * minSize)
+        {
             splitHorizontally = false;
+        }
         else
-            return; // 더 이상 분할 불가
+        {
+            CreateRoom();
+            return;
+        }
 
         if (splitHorizontally)
         {
-            int splitMin = Mathf.FloorToInt(Area.width * 0.3f);
-            int splitMax = Mathf.FloorToInt(Area.width * 0.8f);
-            if (splitMax <= minSize) return;
+            var splitMin = Mathf.FloorToInt(Area.width * 0.3f);
+            var splitMax = Mathf.FloorToInt(Area.width * 0.8f);
+            if (splitMax <= minSize)
+            {
+                CreateRoom();
+                return;
+            }
 
-            int splitX = Random.Range(splitMin, splitMax);
+            var splitX = Random.Range(splitMin, splitMax);
             Left = new BSPNode(new RectInt(Area.x, Area.y, splitX, Area.height));
             Right = new BSPNode(new RectInt(Area.x + splitX, Area.y, Area.width - splitX, Area.height));
         }
         else
         {
-            int splitMin = Mathf.FloorToInt(Area.height * 0.3f);
-            int splitMax = Mathf.FloorToInt(Area.height * 0.8f);
-            if (splitMax <= minSize) return;
+            var splitMin = Mathf.FloorToInt(Area.height * 0.3f);
+            var splitMax = Mathf.FloorToInt(Area.height * 0.8f);
+            if (splitMax <= minSize)
+            {
+                CreateRoom();
+                return;
+            }
 
-            int splitY = Random.Range(splitMin, splitMax);
+            var splitY = Random.Range(splitMin, splitMax);
             Left = new BSPNode(new RectInt(Area.x, Area.y, Area.width, splitY));
             Right = new BSPNode(new RectInt(Area.x, Area.y + splitY, Area.width, Area.height - splitY));
         }
 
         Left.Split(minSize);
         Right.Split(minSize);
-
-        // Leaf 노드에 방 생성
-        if (Left.IsLeaf) Left.CreateRoom();
-        if (Right.IsLeaf) Right.CreateRoom();
     }
 
     public void CreateRoom(int margin = 1)
     {
-        int roomWidth = Random.Range(Area.width / 2, Area.width - margin);
-        int roomHeight = Random.Range(Area.height / 2, Area.height - margin);
-        int roomX = Area.x + Random.Range(1, Area.width - roomWidth - 1);
-        int roomY = Area.y + Random.Range(1, Area.height - roomHeight - 1);
+        if (Area.width <= margin * 2 + 2 || Area.height <= margin * 2 + 2)
+        {
+            room = Area;
+            return;
+        }
+
+        var roomWidthMin = Mathf.Max(1, Area.width / 2);
+        var roomHeightMin = Mathf.Max(1, Area.height / 2);
+        var roomWidthMax = Mathf.Max(roomWidthMin + 1, Area.width - margin);
+        var roomHeightMax = Mathf.Max(roomHeightMin + 1, Area.height - margin);
+
+        var roomWidth = Random.Range(roomWidthMin, roomWidthMax);
+        var roomHeight = Random.Range(roomHeightMin, roomHeightMax);
+        var roomXMax = Mathf.Max(margin + 1, Area.width - roomWidth - margin);
+        var roomYMax = Mathf.Max(margin + 1, Area.height - roomHeight - margin);
+        var roomX = Area.x + Random.Range(margin, roomXMax);
+        var roomY = Area.y + Random.Range(margin, roomYMax);
 
         room = new RectInt(roomX, roomY, roomWidth, roomHeight);
     }
 
-
-
     public List<RectInt> GetRooms()
     {
-        List<RectInt> rooms = new List<RectInt>();
+        var rooms = new List<RectInt>();
         if (IsLeaf)
         {
-            rooms.Add(Area);
+            rooms.Add(room.width > 0 && room.height > 0 ? room : Area);
         }
         else
         {
             rooms.AddRange(Left.GetRooms());
             rooms.AddRange(Right.GetRooms());
         }
+
         return rooms;
     }
 
     public Vector2Int GetRoomCenter()
     {
         if (room.width == 0 || room.height == 0)
+        {
             return new Vector2Int(Area.x + Area.width / 2, Area.y + Area.height / 2);
+        }
+
         return new Vector2Int(room.x + room.width / 2, room.y + room.height / 2);
     }
-
 }

--- a/Assets/Scripts/Manager/ChunkManager/Chunk.cs
+++ b/Assets/Scripts/Manager/ChunkManager/Chunk.cs
@@ -2,9 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.AI.Navigation;
-using Unity.VisualScripting;
 using UnityEngine;
-using UnityEngine.AI;
 
 public class Chunk
 {
@@ -14,7 +12,7 @@ public class Chunk
     public bool IsGenerate = false;
     public bool IsGenerateMonster = false;
     public bool IsCombineMesh = false;
-    public HashSet<Vector2> CheckDirection = new HashSet<Vector2>();
+    public HashSet<Vector2Int> CheckDirection = new HashSet<Vector2Int>();
     public RectInt Bounds;
     public List<Vector3> floorPosData;
 
@@ -57,11 +55,16 @@ public class Chunk
         {
             IsGenerate = true;
             ChunkManager.Instance.Generator.GenerateChunk(Bounds, ChunkObject.transform, minRoomSize, blockSize, out floorPosData);
-            navMeshModifiers = ChunkObject.transform.GetComponentsInChildren<NavMeshModifier>(true);
+            RefreshNavMeshModifiers();
         }
     }
 
-    public bool IsCheckClosedChunk(Vector2 dir)
+    public void RefreshNavMeshModifiers()
+    {
+        navMeshModifiers = ChunkObject.transform.GetComponentsInChildren<NavMeshModifier>(true);
+    }
+
+    public bool IsCheckClosedChunk(Vector2Int dir)
     {
         if (CheckDirection.Contains(dir) == false)
         {

--- a/Assets/Scripts/Manager/ChunkManager/Chunk.cs
+++ b/Assets/Scripts/Manager/ChunkManager/Chunk.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using Unity.AI.Navigation;
 using UnityEngine;
@@ -50,14 +51,18 @@ public class Chunk
         ChunkObject.SetActive(false);
     }
 
-    public void Generate(int minRoomSize, Vector3Int blockSize)
+    public IEnumerator GenerateRoutine(int minRoomSize, Vector3Int blockSize)
     {
-        if (!IsGenerate)
-        {
-            IsGenerate = true;
-            ChunkManager.Instance.Generator.GenerateChunk(Bounds, ChunkObject.transform, minRoomSize, blockSize, out floorPosData);
-            RefreshNavMeshModifiers();
-        }
+        if (IsGenerate) yield break;
+
+        IsGenerate = true;
+        yield return ChunkManager.Instance.Generator.GenerateChunkRoutine(
+            Bounds,
+            ChunkObject.transform,
+            minRoomSize,
+            blockSize,
+            result => floorPosData = result);
+        RefreshNavMeshModifiers();
     }
 
     public void RefreshNavMeshModifiers()

--- a/Assets/Scripts/Manager/ChunkManager/Chunk.cs
+++ b/Assets/Scripts/Manager/ChunkManager/Chunk.cs
@@ -1,6 +1,4 @@
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.AI.Navigation;
 using UnityEngine;
 
@@ -12,7 +10,10 @@ public class Chunk
     public bool IsGenerate = false;
     public bool IsGenerateMonster = false;
     public bool IsCombineMesh = false;
+    public bool IsCombiningMesh = false;
+    public bool NeedsMeshRebuild = false;
     public HashSet<Vector2Int> CheckDirection = new HashSet<Vector2Int>();
+    public List<GameObject> CombinedMeshObjects = new List<GameObject>();
     public RectInt Bounds;
     public List<Vector3> floorPosData;
 

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -83,9 +83,10 @@ public class ChunkManager : ManagerBase<ChunkManager>
                 var coord = m_playerChunk + offset;
                 var inView = offset.sqrMagnitude < ViewRadius * ViewRadius;
 
-                if (init == false && inView)
+                if (inView)
                 {
-                    LoadOrGenerateChunk(coord);
+                    var shouldQueueSpawn = init == false || offset != Vector2Int.zero;
+                    LoadOrGenerateChunk(coord, shouldQueueSpawn);
                     m_loadedCoords.Add(coord);
                 }
                 else
@@ -93,14 +94,6 @@ public class ChunkManager : ManagerBase<ChunkManager>
                     if (m_chunks.TryGetValue(coord, out var chunk))
                     {
                         chunk.Unload();
-                    }
-                    else if (init)
-                    {
-                        chunk = GetOrCreateChunk(coord);
-                        if (offset == Vector2Int.zero)
-                        {
-                            chunk.IsGenerateMonster = true;
-                        }
                     }
                 }
             }
@@ -117,7 +110,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
         }
     }
 
-    private void LoadOrGenerateChunk(Vector2Int coord)
+    private void LoadOrGenerateChunk(Vector2Int coord, bool queueSpawn)
     {
         var chunk = GetOrCreateChunk(coord);
         var didGenerate = false;
@@ -135,7 +128,12 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
         ConnectNeighborChunk(coord);
 
-        if (didGenerate && chunk.IsGenerateMonster == false)
+        if (didGenerate && queueSpawn == false)
+        {
+            chunk.IsGenerateMonster = true;
+        }
+
+        if (didGenerate && queueSpawn && chunk.IsGenerateMonster == false)
         {
             chunk.IsGenerateMonster = true;
             m_pendingSpawnChunks.Add(chunk);
@@ -303,6 +301,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
     private void ProcessPendingChunkSpawns()
     {
         if (m_pendingSpawnChunks.Count == 0) return;
+        if (GameLoop == null || GameLoop.IsStartGame == false) return;
 
         var chunks = m_pendingSpawnChunks.ToArray();
         foreach (var chunk in chunks)

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -1,10 +1,10 @@
 using System.Collections;
 using System.Collections.Generic;
-using Unity.AI.Navigation;
-using UnityEngine.AI;
-using UnityEngine;
-using Cysharp.Threading.Tasks;
 using System.Linq;
+using Cysharp.Threading.Tasks;
+using Unity.AI.Navigation;
+using UnityEngine;
+using UnityEngine.AI;
 
 public class ChunkManager : ManagerBase<ChunkManager>
 {
@@ -15,177 +15,220 @@ public class ChunkManager : ManagerBase<ChunkManager>
     public bool IsBlockUpdateMap = false;
 
     public Transform Player;
-    public Vector3 PlayerSpawnOffset = new Vector3(0 , 2 , 0);
+    public Vector3 PlayerSpawnOffset = new Vector3(0, 2, 0);
     public MapGenerator Generator;
     public InGameLoop GameLoop;
 
     private Vector2Int m_playerChunk;
-    private Dictionary<Vector2Int, Chunk> m_chunks = new Dictionary<Vector2Int, Chunk>();
+    private readonly Dictionary<Vector2Int, Chunk> m_chunks = new();
     private Vector2Int m_lastPlayerChunk;
+    private bool m_hasLastPlayerChunk;
+    private bool m_isUpdatingNavMesh;
+    private bool m_pendingNavMeshUpdate;
+
     [SerializeField] private NavMeshSurface m_surface;
 
     private void Start()
     {
+        GameLoop = InGameLoop.Instance;
+
         if (Player != null)
         {
             MapUpdate(true);
         }
-        GameLoop = InGameLoop.Instance;
+
         IsReady = true;
     }
-    void Update()
+
+    private void Update()
     {
-        if (GameLoop != null && GameLoop.IsStartGame)
+        if (GameLoop == null || GameLoop.IsStartGame == false) return;
+
+        if (IsBlockUpdateMap == false)
         {
-            if (IsBlockUpdateMap == false)
-                MapUpdate(false);
-            NavUpdate();
+            MapUpdate(false);
         }
+
+        NavUpdate();
     }
 
     private void MapUpdate(bool init)
     {
+        if (Player == null || Generator == null || ChunkSize <= 0 || BlockSize.x <= 0 || BlockSize.z <= 0) return;
+
         m_playerChunk = new Vector2Int(
             Mathf.FloorToInt(Player.position.x / (ChunkSize * BlockSize.x)),
             Mathf.FloorToInt(Player.position.z / (ChunkSize * BlockSize.z))
         );
 
         var range = Mathf.CeilToInt(ViewRadius + 2);
-        for (int i = -range; i < range; i++)
+        var loadedCoords = new HashSet<Vector2Int>();
+        for (var i = -range; i < range; i++)
         {
-            for (int j = -range; j < range; j++)
+            for (var j = -range; j < range; j++)
             {
                 var offset = new Vector2Int(i, j);
-                Vector2Int coord = m_playerChunk + offset;
-                bool inView = offset.sqrMagnitude < ViewRadius * ViewRadius;
+                var coord = m_playerChunk + offset;
+                var inView = offset.sqrMagnitude < ViewRadius * ViewRadius;
 
-                // 시야 내부인 경우, 청크 관리
                 if (init == false && inView)
                 {
-                    var chunk = m_chunks[coord];
-                    if (chunk.IsGenerate)
-                    {
-                        if (chunk.IsLoaded == false)
-                        {
-                            chunk.Load();
-                            ConnectNeighborChunk(coord);
-                        }
-                    }
-                    // 생성 안된 경우는 일단 생성
-                    else
-                    {
-                        chunk.Generate(MinRoomSize, BlockSize);
-                        // 필요한 스포너 같이 동작
-                        if (GameLoop != null
-                            && chunk.IsGenerateMonster == false)
-                        {
-                            chunk.IsGenerateMonster = true;
-                            GameLoop.EnemySpawner.RandomUnitSpawnPerChunk(chunk);
-                            GameLoop.NPCSpawner.RandomUnitSpawnPerChunk(chunk);
-                        }
-                    }
+                    LoadOrGenerateChunk(coord);
+                    loadedCoords.Add(coord);
                 }
-                // 시야 밖인 경우, 청크 생성 or Unload
                 else
                 {
                     if (m_chunks.TryGetValue(coord, out var chunk))
                     {
                         chunk.Unload();
                     }
-                    else
+                    else if (init)
                     {
-                        m_chunks[coord] = new Chunk(coord, ChunkSize, BlockSize, transform);
-                        if (init == true && offset == Vector2Int.zero)
+                        chunk = GetOrCreateChunk(coord);
+                        if (offset == Vector2Int.zero)
                         {
-                            m_chunks[coord].IsGenerateMonster = true;
+                            chunk.IsGenerateMonster = true;
                         }
                     }
                 }
             }
         }
+
+        if (init) return;
+
+        foreach (var pair in m_chunks)
+        {
+            if (loadedCoords.Contains(pair.Key) == false)
+            {
+                pair.Value.Unload();
+            }
+        }
+    }
+
+    private void LoadOrGenerateChunk(Vector2Int coord)
+    {
+        var chunk = GetOrCreateChunk(coord);
+        var didGenerate = false;
+
+        if (chunk.IsGenerate == false)
+        {
+            chunk.Generate(MinRoomSize, BlockSize);
+            didGenerate = true;
+        }
+
+        if (chunk.IsLoaded == false)
+        {
+            chunk.Load();
+        }
+
+        ConnectNeighborChunk(coord);
+
+        if (didGenerate && chunk.IsGenerateMonster == false)
+        {
+            chunk.IsGenerateMonster = true;
+            GameLoop?.EnemySpawner?.RandomUnitSpawnPerChunk(chunk);
+            GameLoop?.NPCSpawner?.RandomUnitSpawnPerChunk(chunk);
+        }
+    }
+
+    private Chunk GetOrCreateChunk(Vector2Int coord)
+    {
+        if (m_chunks.TryGetValue(coord, out var chunk))
+        {
+            return chunk;
+        }
+
+        chunk = new Chunk(coord, ChunkSize, BlockSize, transform);
+        m_chunks[coord] = chunk;
+        return chunk;
     }
 
     private void NavUpdate()
     {
-        if (m_playerChunk != m_lastPlayerChunk)
+        if (m_hasLastPlayerChunk == false || m_playerChunk != m_lastPlayerChunk)
         {
-            // 맵 업데이트
-            if (m_surface != null)
-            {
-                //m_surface.UpdateNavMesh(m_surface.navMeshData);
-                //StartCoroutine(UpdateMapRoutine());
-                UpdateMapRoutine().Forget();
-            }
+            UpdateMapRoutine().Forget();
         }
+
         m_lastPlayerChunk = m_playerChunk;
+        m_hasLastPlayerChunk = true;
     }
 
     public async UniTaskVoid UpdateMapRoutine()
     {
+        if (m_surface == null || m_surface.navMeshData == null) return;
+
+        if (m_isUpdatingNavMesh)
+        {
+            m_pendingNavMeshUpdate = true;
+            return;
+        }
+
+        m_isUpdatingNavMesh = true;
+        m_pendingNavMeshUpdate = false;
+
         var data = m_surface.navMeshData;
         var setting = m_surface.GetBuildSettings();
-        List<NavMeshBuildMarkup> markups = new();
-        int count = 0;
-        int batchSize = 50;
+        var markups = new List<NavMeshBuildMarkup>();
+        var count = 0;
+        const int batchSize = 50;
         var snap = m_chunks.ToArray();
+
         foreach (var chunk in snap)
         {
-            if (chunk.Value.IsLoaded)
-            {
-                var modifiers = chunk.Value.navMeshModifiers;
-                foreach (var mod in modifiers)
-                {
-                    if (mod == null) continue;
+            if (chunk.Value.IsLoaded == false) continue;
 
-                    var item = new NavMeshBuildMarkup
-                    {
-                        root = mod.transform,
-                        overrideArea = mod.overrideArea,
-                        area = mod.area,
-                        ignoreFromBuild = mod.ignoreFromBuild,
-                    };
-                    markups.Add(item);
-                    count++;
-                    if (count % batchSize == 0)
-                        await UniTask.Yield();
+            var modifiers = chunk.Value.navMeshModifiers;
+            if (modifiers == null) continue;
+
+            foreach (var mod in modifiers)
+            {
+                if (mod == null) continue;
+
+                markups.Add(new NavMeshBuildMarkup
+                {
+                    root = mod.transform,
+                    overrideArea = mod.overrideArea,
+                    area = mod.area,
+                    ignoreFromBuild = mod.ignoreFromBuild,
+                });
+
+                count++;
+                if (count % batchSize == 0)
+                {
+                    await UniTask.Yield();
                 }
             }
         }
+
+        var sources = new List<NavMeshBuildSource>();
+        NavMeshBuilder.CollectSources(transform, ~0, NavMeshCollectGeometry.PhysicsColliders, 0, markups, sources);
+        await UniTask.Yield();
+
+        var worldToLocal = Matrix4x4.TRS(transform.position, transform.rotation, Vector3.one).inverse;
+        var result = new Bounds();
         count = 0;
 
-        // modifier은 비활성화 한 채로, 수동으로 마크업 추가
-
-        List<NavMeshBuildSource> sources = new();
-        NavMeshBuilder.CollectSources(
-            transform, ~0, NavMeshCollectGeometry.PhysicsColliders, 0, markups, sources);
-        await UniTask.Yield();
-
-        Matrix4x4 worldToLocal = Matrix4x4.TRS(transform.position, transform.rotation, Vector3.one);
-        worldToLocal = worldToLocal.inverse;
-        await UniTask.Yield();
-
-        var result = new Bounds();
         foreach (var src in sources)
         {
             switch (src.shape)
             {
                 case NavMeshBuildSourceShape.Mesh:
+                    if (src.sourceObject is Mesh mesh)
                     {
-                        var m = src.sourceObject as Mesh;
-                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, m.bounds));
-                        break;
+                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, mesh.bounds));
                     }
+                    break;
                 case NavMeshBuildSourceShape.Terrain:
-                    {
 #if NMC_CAN_ACCESS_TERRAIN
-                        // Terrain pivot is lower/left corner - shift bounds accordingly
-                        var t = src.sourceObject as TerrainData;
-                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(0.5f * t.size, t.size)));
-#else
-                        Debug.LogWarning("The NavMesh cannot be properly baked for the terrain because the necessary functionality is missing. Add the com.unity.modules.terrain package through the Package Manager.");
-#endif
-                        break;
+                    if (src.sourceObject is TerrainData terrain)
+                    {
+                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(0.5f * terrain.size, terrain.size)));
                     }
+#else
+                    Debug.LogWarning("The NavMesh cannot be baked for terrain because the terrain module is unavailable.");
+#endif
+                    break;
                 case NavMeshBuildSourceShape.Box:
                 case NavMeshBuildSourceShape.Sphere:
                 case NavMeshBuildSourceShape.Capsule:
@@ -196,15 +239,23 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
             count++;
             if (count % batchSize == 0)
+            {
                 await UniTask.Yield();
+            }
         }
+
         result.Expand(0.1f);
-
         var process = NavMeshBuilder.UpdateNavMeshDataAsync(data, setting, sources, result);
-        //var process = m_surface.UpdateNavMesh(m_surface.navMeshData);
-        while (!process.isDone) await UniTask.Yield();
+        while (process.isDone == false)
+        {
+            await UniTask.Yield();
+        }
 
-        await UniTask.Yield();
+        m_isUpdatingNavMesh = false;
+        if (m_pendingNavMeshUpdate)
+        {
+            UpdateMapRoutine().Forget();
+        }
     }
 
     private Bounds GetWorldBounds(Matrix4x4 mat, Bounds bounds)
@@ -224,76 +275,72 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     public IEnumerator PlayerStartRoutine()
     {
-        while(true)
+        while (true)
         {
             if (m_chunks.ContainsKey(m_playerChunk) && m_chunks[m_playerChunk].IsLoaded) break;
             yield return null;
         }
+
         var floor = m_chunks[m_playerChunk].floorPosData;
-        Player.transform.position = floor[Random.Range(0, floor.Count)];
+        if (floor == null || floor.Count == 0) yield break;
+
+        Player.transform.position = floor[Random.Range(0, floor.Count)] + PlayerSpawnOffset;
         if (m_surface != null)
         {
-            // 먼저 로딩 후, 커스텀으로 네비 업데이트 (BuildNavMesh의 Time문제)
             m_surface.BuildNavMesh();
             yield return new WaitForSeconds(3f);
             UpdateMapRoutine().Forget();
         }
-
     }
-    public bool TryGetSpawnPointOnChunk(Vector3 pos, Vector3 spawnOffset,out Vector3 res)
+
+    public bool TryGetSpawnPointOnChunk(Vector3 pos, Vector3 spawnOffset, out Vector3 res)
     {
-        res = Vector3.zero;
-        var chunk = GetChunk(pos);
-        if (chunk != null)
-        {
-            var pickFloor = chunk.floorPosData;
-            if (pickFloor != null && pickFloor.Count > 0)
-            {
-                var pickNum = Random.Range(0, pickFloor.Count);
-                res = pickFloor[pickNum] + spawnOffset;
-            }
-            else return false;
-            return true;
-        }
-        else return false;
+        return TryGetSpawnPointOnChunk(GetChunk(pos), spawnOffset, out res);
     }
 
     public bool TryGetSpawnPointOnChunk(Chunk chunk, Vector3 spawnOffset, out Vector3 res)
     {
         res = Vector3.zero;
-        if (chunk != null)
+        if (chunk == null || chunk.floorPosData == null || chunk.floorPosData.Count == 0)
         {
-            var pickFloor = chunk.floorPosData;
-            if (pickFloor != null && pickFloor.Count > 0)
-            {
-                var pickNum = Random.Range(0, pickFloor.Count);
-                res = pickFloor[pickNum] + spawnOffset;
-            }
-            else return false;
-            return true;
+            return false;
         }
-        else return false;
+
+        const int maxAttempts = 12;
+        for (var i = 0; i < maxAttempts; i++)
+        {
+            var pickNum = Random.Range(0, chunk.floorPosData.Count);
+            var candidate = chunk.floorPosData[pickNum] + spawnOffset;
+
+            if (NavMesh.SamplePosition(candidate, out var hit, Mathf.Max(BlockSize.x, BlockSize.z) * 2f, NavMesh.AllAreas))
+            {
+                res = hit.position;
+                return true;
+            }
+
+            res = candidate;
+        }
+
+        return true;
     }
 
-
-    // RandomPoint.y has -999f 
-    public Vector3 GetRandomSpawnPoint(Vector3 center,float minDist,float maxDist)
+    public Vector3 GetRandomSpawnPoint(Vector3 center, float minDist, float maxDist)
     {
-        Vector3 res = Vector3.zero;
-        Vector2 dir = Random.insideUnitCircle.normalized;
+        var dir = Random.insideUnitCircle.normalized;
         var dist = Random.Range(minDist, maxDist);
-        Vector3 point = (Vector3)(dir * dist) + center;
-        res = new Vector3(point.x, -999f , point.z);
-        return res;
+        var point = (Vector3)(dir * dist) + center;
+        return new Vector3(point.x, -999f, point.z);
     }
 
     public Chunk GetChunk(Vector2Int pos)
     {
-        return m_chunks.TryGetValue(pos,out var res)? res: null;
+        return m_chunks.TryGetValue(pos, out var res) ? res : null;
     }
 
     public Chunk GetChunk(Vector3 pos)
     {
+        if (ChunkSize <= 0 || BlockSize.x <= 0 || BlockSize.z <= 0) return null;
+
         var currentChunk = new Vector2Int(
             Mathf.FloorToInt(pos.x / (ChunkSize * BlockSize.x)),
             Mathf.FloorToInt(pos.z / (ChunkSize * BlockSize.z))
@@ -303,107 +350,92 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     private void ConnectNeighborChunk(Vector2Int chunkCoord)
     {
-        Vector2Int[] dirs = {
-        Vector2Int.up, Vector2Int.down,
-        Vector2Int.left, Vector2Int.right
+        Vector2Int[] dirs =
+        {
+            Vector2Int.up,
+            Vector2Int.down,
+            Vector2Int.left,
+            Vector2Int.right
         };
 
         foreach (var dir in dirs)
         {
-            Vector2Int neighborCoord = chunkCoord + dir;
-            if (m_chunks.ContainsKey(neighborCoord))
-            {
-                Chunk currentChunk = m_chunks[chunkCoord];
-                Chunk neighborChunk = m_chunks[neighborCoord];
+            var neighborCoord = chunkCoord + dir;
+            if (m_chunks.ContainsKey(neighborCoord) == false) continue;
 
-                if (currentChunk.IsLoaded && neighborChunk.IsLoaded)
-                {
-                    if (currentChunk.IsCheckClosedChunk(dir)) continue;
-                    
-                    Generator.TryConnectChunks(
-                        currentChunk,
-                        dir,
-                        BlockSize,
-                        currentChunk.ChunkObject.transform
-                    );
+            var currentChunk = m_chunks[chunkCoord];
+            var neighborChunk = m_chunks[neighborCoord];
+            if (currentChunk.IsLoaded == false || neighborChunk.IsLoaded == false) continue;
+            if (currentChunk.IsCheckClosedChunk(dir)) continue;
 
-                    // 서로에 대해서 체크
-                    currentChunk.CheckDirection.Add(dir);
-                    neighborChunk.CheckDirection.Add(-dir);
-                    // 끝난 후, 두 청크의 맵 구조는 확정되었으므로 메쉬 합쳐서 최적화
-                    StartCoroutine(CombineMesh(currentChunk));
-                    StartCoroutine(CombineMesh(neighborChunk));
-                }
-            }
+            var isConnected = Generator.TryConnectChunks(currentChunk, dir, BlockSize, currentChunk.ChunkObject.transform);
+            if (isConnected == false) continue;
+
+            currentChunk.CheckDirection.Add(dir);
+            neighborChunk.CheckDirection.Add(-dir);
+            currentChunk.RefreshNavMeshModifiers();
+            neighborChunk.RefreshNavMeshModifiers();
+            StartCoroutine(CombineMesh(currentChunk));
+            StartCoroutine(CombineMesh(neighborChunk));
         }
     }
 
     private IEnumerator CombineMesh(Chunk chunk)
     {
-        // 이미 수행했거나 수행중이면 함수 리턴
         if (chunk.IsCombineMesh || chunk.CheckDirection.Count != 4) yield break;
         chunk.IsCombineMesh = true;
         yield return null;
 
-        MeshFilter[] meshFilters = chunk.ChunkObject.GetComponentsInChildren<MeshFilter>();
+        var meshFilters = chunk.ChunkObject.GetComponentsInChildren<MeshFilter>();
+        var tileNames = new List<string>();
 
-        List<string> list = new();
-
-        for (int i = 0; i < (int)TileType.Size; i++)
+        for (var i = 0; i < (int)TileType.Size; i++)
         {
-            list.Add(((TileType)i).ToString());
+            tileNames.Add(((TileType)i).ToString());
         }
 
-        foreach(var item in list)
+        foreach (var tileName in tileNames)
         {
-            var createObject = new GameObject(item);
+            var createObject = new GameObject(tileName);
             createObject.transform.parent = chunk.ChunkObject.transform;
 
-            List<CombineInstance> combineList = new List<CombineInstance>();
-            var layer = LayerMask.NameToLayer(item);
+            var combineList = new List<CombineInstance>();
+            var layer = LayerMask.NameToLayer(tileName);
             Material mat = null;
 
-            for (int i = 0; i < meshFilters.Length; i++)
+            foreach (var filter in meshFilters)
             {
-                var filter = meshFilters[i];
-
-                // 자기 자신이면 or 같은 레이어 아니면 제외
                 if (filter.transform == chunk.ChunkObject.transform || filter.gameObject.layer != layer) continue;
                 if (filter.sharedMesh == null) continue;
 
-                CombineInstance ci = new CombineInstance
+                var renderer = filter.GetComponentInChildren<MeshRenderer>();
+                if (renderer != null)
+                {
+                    renderer.enabled = false;
+                    mat ??= renderer.sharedMaterial;
+                }
+
+                combineList.Add(new CombineInstance
                 {
                     mesh = filter.sharedMesh,
                     transform = filter.transform.localToWorldMatrix
-                };
-                var renderer = filter.GetComponentInChildren<MeshRenderer>();
-                renderer.enabled = false;
-                combineList.Add(ci);
-                if (mat == null)
-                {
-                    if (renderer != null)
-                    {
-                        mat = renderer.sharedMaterial;
-                    }
-                }
+                });
             }
 
             if (combineList.Count > 0)
             {
-                Mesh mesh = new Mesh();
+                var mesh = new Mesh();
                 mesh.CombineMeshes(combineList.ToArray(), true, true);
 
                 var filter = createObject.AddComponent<MeshFilter>();
                 var renderer = createObject.AddComponent<MeshRenderer>();
 
                 filter.mesh = mesh;
-                renderer.sharedMaterial = mat; // 필요한 머티리얼 할당
-
+                renderer.sharedMaterial = mat;
                 createObject.layer = layer;
-
             }
-            yield return null;
 
+            yield return null;
         }
     }
 }

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -5,6 +5,7 @@ using Cysharp.Threading.Tasks;
 using Unity.AI.Navigation;
 using UnityEngine;
 using UnityEngine.AI;
+using UnityEngine.Rendering;
 
 public class ChunkManager : ManagerBase<ChunkManager>
 {
@@ -127,6 +128,10 @@ public class ChunkManager : ManagerBase<ChunkManager>
         }
 
         ConnectNeighborChunk(coord);
+        if (chunk.IsCombineMesh == false && chunk.IsCombiningMesh == false)
+        {
+            RequestCombineMesh(chunk);
+        }
 
         if (didGenerate && queueSpawn == false)
         {
@@ -434,67 +439,112 @@ public class ChunkManager : ManagerBase<ChunkManager>
             neighborChunk.CheckDirection.Add(-dir);
             currentChunk.RefreshNavMeshModifiers();
             neighborChunk.RefreshNavMeshModifiers();
-            StartCoroutine(CombineMesh(currentChunk));
-            StartCoroutine(CombineMesh(neighborChunk));
+            RequestCombineMesh(currentChunk);
+            RequestCombineMesh(neighborChunk);
+        }
+    }
+
+    private void RequestCombineMesh(Chunk chunk)
+    {
+        if (chunk == null || chunk.IsLoaded == false) return;
+
+        chunk.NeedsMeshRebuild = true;
+        if (chunk.IsCombiningMesh == false)
+        {
+            StartCoroutine(CombineMesh(chunk));
         }
     }
 
     private IEnumerator CombineMesh(Chunk chunk)
     {
-        if (chunk.IsCombineMesh || chunk.CheckDirection.Count != 4) yield break;
-        chunk.IsCombineMesh = true;
-        yield return null;
+        if (chunk == null || chunk.IsCombiningMesh) yield break;
 
-        var meshFilters = chunk.ChunkObject.GetComponentsInChildren<MeshFilter>();
-        var tileNames = new List<string>();
-
-        for (var i = 0; i < (int)TileType.Size; i++)
+        chunk.IsCombiningMesh = true;
+        while (chunk.NeedsMeshRebuild)
         {
-            tileNames.Add(((TileType)i).ToString());
-        }
+            chunk.NeedsMeshRebuild = false;
+            yield return null;
 
-        foreach (var tileName in tileNames)
-        {
-            var createObject = new GameObject(tileName);
-            createObject.transform.parent = chunk.ChunkObject.transform;
-
-            var combineList = new List<CombineInstance>();
-            var layer = LayerMask.NameToLayer(tileName);
-            Material mat = null;
-
-            foreach (var filter in meshFilters)
+            var previousCombinedRoots = new HashSet<Transform>();
+            foreach (var combinedObject in chunk.CombinedMeshObjects)
             {
-                if (filter.transform == chunk.ChunkObject.transform || filter.gameObject.layer != layer) continue;
-                if (filter.sharedMesh == null) continue;
+                if (combinedObject == null) continue;
 
-                var renderer = filter.GetComponentInChildren<MeshRenderer>();
-                if (renderer != null)
+                previousCombinedRoots.Add(combinedObject.transform);
+                var combinedFilter = combinedObject.GetComponent<MeshFilter>();
+                if (combinedFilter != null && combinedFilter.sharedMesh != null)
                 {
-                    renderer.enabled = false;
-                    mat ??= renderer.sharedMaterial;
+                    Destroy(combinedFilter.sharedMesh);
+                }
+
+                Destroy(combinedObject);
+            }
+            chunk.CombinedMeshObjects.Clear();
+
+            var groupedMeshes = new Dictionary<(int layer, Material material), List<CombineInstance>>();
+            var meshFilters = chunk.ChunkObject.GetComponentsInChildren<MeshFilter>(true);
+            var worldToChunk = chunk.ChunkObject.transform.worldToLocalMatrix;
+
+            foreach (var sourceFilter in meshFilters)
+            {
+                if (sourceFilter == null || sourceFilter.sharedMesh == null) continue;
+                if (IsUnderCombinedRoot(sourceFilter.transform, previousCombinedRoots)) continue;
+
+                var sourceRenderer = sourceFilter.GetComponent<MeshRenderer>();
+                if (sourceRenderer == null || sourceRenderer.sharedMaterial == null) continue;
+
+                var key = (sourceFilter.gameObject.layer, sourceRenderer.sharedMaterial);
+                if (groupedMeshes.TryGetValue(key, out var combineList) == false)
+                {
+                    combineList = new List<CombineInstance>();
+                    groupedMeshes[key] = combineList;
                 }
 
                 combineList.Add(new CombineInstance
                 {
-                    mesh = filter.sharedMesh,
-                    transform = filter.transform.localToWorldMatrix
+                    mesh = sourceFilter.sharedMesh,
+                    transform = worldToChunk * sourceFilter.transform.localToWorldMatrix
                 });
+                sourceRenderer.enabled = false;
             }
 
-            if (combineList.Count > 0)
+            foreach (var group in groupedMeshes)
             {
+                if (group.Value.Count == 0) continue;
+
+                var createObject = new GameObject($"Combined_{group.Key.layer}_{group.Key.material.name}");
+                createObject.transform.SetParent(chunk.ChunkObject.transform, false);
+                createObject.layer = group.Key.layer;
+
                 var mesh = new Mesh();
-                mesh.CombineMeshes(combineList.ToArray(), true, true);
+                mesh.indexFormat = IndexFormat.UInt32;
+                mesh.CombineMeshes(group.Value.ToArray(), true, true);
+                mesh.RecalculateBounds();
 
                 var filter = createObject.AddComponent<MeshFilter>();
                 var renderer = createObject.AddComponent<MeshRenderer>();
 
-                filter.mesh = mesh;
-                renderer.sharedMaterial = mat;
-                createObject.layer = layer;
+                filter.sharedMesh = mesh;
+                renderer.sharedMaterial = group.Key.material;
+                chunk.CombinedMeshObjects.Add(createObject);
             }
 
             yield return null;
         }
+
+        chunk.IsCombineMesh = chunk.CombinedMeshObjects.Count > 0;
+        chunk.IsCombiningMesh = false;
+    }
+
+    private bool IsUnderCombinedRoot(Transform source, HashSet<Transform> combinedRoots)
+    {
+        var current = source;
+        while (current != null)
+        {
+            if (combinedRoots.Contains(current)) return true;
+            current = current.parent;
+        }
+
+        return false;
     }
 }

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -25,6 +25,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
     private bool m_hasLastPlayerChunk;
     private bool m_isUpdatingNavMesh;
     private bool m_pendingNavMeshUpdate;
+    private readonly HashSet<Chunk> m_pendingSpawnChunks = new();
 
     [SerializeField] private NavMeshSurface m_surface;
 
@@ -126,8 +127,8 @@ public class ChunkManager : ManagerBase<ChunkManager>
         if (didGenerate && chunk.IsGenerateMonster == false)
         {
             chunk.IsGenerateMonster = true;
-            GameLoop?.EnemySpawner?.RandomUnitSpawnPerChunk(chunk);
-            GameLoop?.NPCSpawner?.RandomUnitSpawnPerChunk(chunk);
+            m_pendingSpawnChunks.Add(chunk);
+            UpdateMapRoutine().Forget();
         }
     }
 
@@ -156,7 +157,11 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     public async UniTaskVoid UpdateMapRoutine()
     {
-        if (m_surface == null || m_surface.navMeshData == null) return;
+        if (m_surface == null || m_surface.navMeshData == null)
+        {
+            ProcessPendingChunkSpawns();
+            return;
+        }
 
         if (m_isUpdatingNavMesh)
         {
@@ -255,7 +260,36 @@ public class ChunkManager : ManagerBase<ChunkManager>
         if (m_pendingNavMeshUpdate)
         {
             UpdateMapRoutine().Forget();
+            return;
         }
+
+        ProcessPendingChunkSpawns();
+    }
+
+    private void ProcessPendingChunkSpawns()
+    {
+        if (m_pendingSpawnChunks.Count == 0) return;
+
+        var chunks = m_pendingSpawnChunks.ToArray();
+        foreach (var chunk in chunks)
+        {
+            if (chunk == null || chunk.IsLoaded == false)
+            {
+                m_pendingSpawnChunks.Remove(chunk);
+                continue;
+            }
+
+            if (CanSpawnOnChunk(chunk) == false) continue;
+
+            GameLoop?.EnemySpawner?.RandomUnitSpawnPerChunk(chunk);
+            GameLoop?.NPCSpawner?.RandomUnitSpawnPerChunk(chunk);
+            m_pendingSpawnChunks.Remove(chunk);
+        }
+    }
+
+    private bool CanSpawnOnChunk(Chunk chunk)
+    {
+        return TryGetSpawnPointOnChunk(chunk, Vector3.up, out _);
     }
 
     private Bounds GetWorldBounds(Matrix4x4 mat, Bounds bounds)
@@ -321,7 +355,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
             res = candidate;
         }
 
-        return true;
+        return false;
     }
 
     public Vector3 GetRandomSpawnPoint(Vector3 center, float minDist, float maxDist)

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -437,6 +437,12 @@ public class ChunkManager : ManagerBase<ChunkManager>
             if (m_surface.navMeshData == null)
             {
                 m_surface.BuildNavMesh();
+                yield return null;
+                while (GameLoop != null && GameLoop.IsStartGame == false)
+                {
+                    yield return null;
+                }
+                ProcessPendingChunkSpawns();
             }
             else
             {

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -29,6 +29,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
     private bool m_pendingNavMeshUpdate;
     private bool m_isNavMeshUpdateQueued;
     private readonly HashSet<Chunk> m_pendingSpawnChunks = new();
+    private readonly HashSet<int> m_combinableTileLayers = new();
     private static readonly Vector2Int[] NeighborDirs =
     {
         Vector2Int.up,
@@ -42,6 +43,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
     private IEnumerator Start()
     {
         GameLoop = InGameLoop.Instance;
+        CacheCombinableTileLayers();
 
         if (Generator != null)
         {
@@ -510,6 +512,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
             {
                 if (sourceFilter == null || sourceFilter.sharedMesh == null) continue;
                 if (IsUnderCombinedRoot(sourceFilter.transform, previousCombinedRoots)) continue;
+                if (m_combinableTileLayers.Contains(sourceFilter.gameObject.layer) == false) continue;
 
                 var sourceRenderer = sourceFilter.GetComponent<MeshRenderer>();
                 if (sourceRenderer == null || sourceRenderer.sharedMaterial == null) continue;
@@ -555,6 +558,25 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
         chunk.IsCombineMesh = chunk.CombinedMeshObjects.Count > 0;
         chunk.IsCombiningMesh = false;
+    }
+
+    private void CacheCombinableTileLayers()
+    {
+        m_combinableTileLayers.Clear();
+        AddCombinableTileLayer("Floor");
+        AddCombinableTileLayer("Wall");
+        AddCombinableTileLayer("Pillar");
+        AddCombinableTileLayer("Ceiling");
+        AddCombinableTileLayer("Gate");
+    }
+
+    private void AddCombinableTileLayer(string layerName)
+    {
+        var layer = LayerMask.NameToLayer(layerName);
+        if (layer >= 0)
+        {
+            m_combinableTileLayers.Add(layer);
+        }
     }
 
     private bool IsUnderCombinedRoot(Transform source, HashSet<Transform> combinedRoots)

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -23,9 +23,8 @@ public class ChunkManager : ManagerBase<ChunkManager>
     private Vector2Int m_playerChunk;
     private readonly Dictionary<Vector2Int, Chunk> m_chunks = new();
     private readonly HashSet<Vector2Int> m_loadedCoords = new();
-    private Vector2Int m_lastPlayerChunk;
     private bool m_hasPlayerChunk;
-    private bool m_hasLastPlayerChunk;
+    private bool m_isMapUpdating;
     private bool m_isUpdatingNavMesh;
     private bool m_pendingNavMeshUpdate;
     private bool m_isNavMeshUpdateQueued;
@@ -40,13 +39,21 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     [SerializeField] private NavMeshSurface m_surface;
 
-    private void Start()
+    private IEnumerator Start()
     {
         GameLoop = InGameLoop.Instance;
 
-        if (Player != null)
+        if (Generator != null)
         {
-            MapUpdate(true);
+            while (Generator.IsReady == false)
+            {
+                yield return null;
+            }
+        }
+
+        if (Player != null && Generator != null)
+        {
+            yield return MapUpdateRoutine(true);
         }
 
         IsReady = true;
@@ -58,18 +65,31 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
         if (IsBlockUpdateMap == false)
         {
-            MapUpdate(false);
+            RequestMapUpdate();
         }
-
-        NavUpdate();
     }
 
-    private void MapUpdate(bool init)
+    private void RequestMapUpdate()
     {
-        if (Player == null || Generator == null || ChunkSize <= 0 || BlockSize.x <= 0 || BlockSize.z <= 0) return;
+        if (m_isMapUpdating || Player == null || Generator == null || ChunkSize <= 0 || BlockSize.x <= 0 || BlockSize.z <= 0) return;
 
         var nextPlayerChunk = GetPlayerChunkCoord(Player.position);
-        if (init == false && m_hasPlayerChunk && nextPlayerChunk == m_playerChunk) return;
+        if (m_hasPlayerChunk && nextPlayerChunk == m_playerChunk) return;
+
+        StartCoroutine(MapUpdateRoutine(false));
+    }
+
+    private IEnumerator MapUpdateRoutine(bool init)
+    {
+        if (Player == null || Generator == null || ChunkSize <= 0 || BlockSize.x <= 0 || BlockSize.z <= 0) yield break;
+
+        m_isMapUpdating = true;
+        var nextPlayerChunk = GetPlayerChunkCoord(Player.position);
+        if (init == false && m_hasPlayerChunk && nextPlayerChunk == m_playerChunk)
+        {
+            m_isMapUpdating = false;
+            yield break;
+        }
 
         m_playerChunk = nextPlayerChunk;
         m_hasPlayerChunk = true;
@@ -87,7 +107,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
                 if (inView)
                 {
                     var shouldQueueSpawn = init == false || offset != Vector2Int.zero;
-                    LoadOrGenerateChunk(coord, shouldQueueSpawn);
+                    yield return LoadOrGenerateChunkRoutine(coord, shouldQueueSpawn);
                     m_loadedCoords.Add(coord);
                 }
                 else
@@ -100,25 +120,29 @@ public class ChunkManager : ManagerBase<ChunkManager>
             }
         }
 
-        if (init) return;
-
-        foreach (var pair in m_chunks)
+        if (init == false)
         {
-            if (m_loadedCoords.Contains(pair.Key) == false)
+            foreach (var pair in m_chunks)
             {
-                pair.Value.Unload();
+                if (m_loadedCoords.Contains(pair.Key) == false)
+                {
+                    pair.Value.Unload();
+                }
             }
         }
+
+        m_isMapUpdating = false;
+        RequestNavMeshUpdate();
     }
 
-    private void LoadOrGenerateChunk(Vector2Int coord, bool queueSpawn)
+    private IEnumerator LoadOrGenerateChunkRoutine(Vector2Int coord, bool queueSpawn)
     {
         var chunk = GetOrCreateChunk(coord);
         var didGenerate = false;
 
         if (chunk.IsGenerate == false)
         {
-            chunk.Generate(MinRoomSize, BlockSize);
+            yield return chunk.GenerateRoutine(MinRoomSize, BlockSize);
             didGenerate = true;
         }
 
@@ -142,7 +166,6 @@ public class ChunkManager : ManagerBase<ChunkManager>
         {
             chunk.IsGenerateMonster = true;
             m_pendingSpawnChunks.Add(chunk);
-            RequestNavMeshUpdate();
         }
     }
 
@@ -164,17 +187,6 @@ public class ChunkManager : ManagerBase<ChunkManager>
             Mathf.FloorToInt(position.x / (ChunkSize * BlockSize.x)),
             Mathf.FloorToInt(position.z / (ChunkSize * BlockSize.z))
         );
-    }
-
-    private void NavUpdate()
-    {
-        if (m_hasLastPlayerChunk == false || m_playerChunk != m_lastPlayerChunk)
-        {
-            RequestNavMeshUpdate();
-        }
-
-        m_lastPlayerChunk = m_playerChunk;
-        m_hasLastPlayerChunk = true;
     }
 
     private void RequestNavMeshUpdate()
@@ -359,9 +371,18 @@ public class ChunkManager : ManagerBase<ChunkManager>
         Player.transform.position = floor[Random.Range(0, floor.Count)] + PlayerSpawnOffset;
         if (m_surface != null)
         {
-            m_surface.BuildNavMesh();
-            yield return new WaitForSeconds(3f);
-            RequestNavMeshUpdate();
+            if (m_surface.navMeshData == null)
+            {
+                m_surface.BuildNavMesh();
+            }
+            else
+            {
+                RequestNavMeshUpdate();
+                while (m_isNavMeshUpdateQueued || m_isUpdatingNavMesh)
+                {
+                    yield return null;
+                }
+            }
         }
     }
 

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -323,8 +323,21 @@ public class ChunkManager : ManagerBase<ChunkManager>
         await UniTask.Yield();
 
         var worldToLocal = Matrix4x4.TRS(transform.position, transform.rotation, Vector3.one).inverse;
-        var result = new Bounds();
+        var result = default(Bounds);
+        var hasBounds = false;
         count = 0;
+
+        void Encapsulate(Bounds bounds)
+        {
+            if (hasBounds)
+            {
+                result.Encapsulate(bounds);
+                return;
+            }
+
+            result = bounds;
+            hasBounds = true;
+        }
 
         foreach (var src in sources)
         {
@@ -333,14 +346,14 @@ public class ChunkManager : ManagerBase<ChunkManager>
                 case NavMeshBuildSourceShape.Mesh:
                     if (src.sourceObject is Mesh mesh)
                     {
-                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, mesh.bounds));
+                        Encapsulate(GetWorldBounds(worldToLocal * src.transform, mesh.bounds));
                     }
                     break;
                 case NavMeshBuildSourceShape.Terrain:
 #if NMC_CAN_ACCESS_TERRAIN
                     if (src.sourceObject is TerrainData terrain)
                     {
-                        result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(0.5f * terrain.size, terrain.size)));
+                        Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(0.5f * terrain.size, terrain.size)));
                     }
 #else
                     Debug.LogWarning("The NavMesh cannot be baked for terrain because the terrain module is unavailable.");
@@ -350,7 +363,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
                 case NavMeshBuildSourceShape.Sphere:
                 case NavMeshBuildSourceShape.Capsule:
                 case NavMeshBuildSourceShape.ModifierBox:
-                    result.Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(Vector3.zero, src.size)));
+                    Encapsulate(GetWorldBounds(worldToLocal * src.transform, new Bounds(Vector3.zero, src.size)));
                     break;
             }
 
@@ -359,6 +372,19 @@ public class ChunkManager : ManagerBase<ChunkManager>
             {
                 await UniTask.Yield();
             }
+        }
+
+        if (hasBounds == false)
+        {
+            m_isUpdatingNavMesh = false;
+            if (m_pendingNavMeshUpdate)
+            {
+                RequestNavMeshUpdate();
+                return;
+            }
+
+            ProcessPendingChunkSpawns();
+            return;
         }
 
         result.Expand(0.1f);

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -402,7 +402,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
             if (currentChunk.IsLoaded == false || neighborChunk.IsLoaded == false) continue;
             if (currentChunk.IsCheckClosedChunk(dir)) continue;
 
-            var isConnected = Generator.TryConnectChunks(currentChunk, dir, BlockSize, currentChunk.ChunkObject.transform);
+            var isConnected = Generator.TryConnectChunks(currentChunk, neighborChunk, dir, BlockSize);
             if (isConnected == false) continue;
 
             currentChunk.CheckDirection.Add(dir);

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -14,6 +14,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
     public int MinRoomSize = 6;
     public Vector3Int BlockSize = Vector3Int.one;
     public bool IsBlockUpdateMap = false;
+    [Min(1)] public int RetainedChunkPadding = 2;
 
     public Transform Player;
     public Vector3 PlayerSpawnOffset = new Vector3(0, 2, 0);
@@ -131,6 +132,8 @@ public class ChunkManager : ManagerBase<ChunkManager>
                     pair.Value.Unload();
                 }
             }
+
+            ReleaseDistantChunks();
         }
 
         m_isMapUpdating = false;
@@ -181,6 +184,64 @@ public class ChunkManager : ManagerBase<ChunkManager>
         chunk = new Chunk(coord, ChunkSize, BlockSize, transform);
         m_chunks[coord] = chunk;
         return chunk;
+    }
+
+    private void ReleaseDistantChunks()
+    {
+        if (m_isUpdatingNavMesh) return;
+
+        var retentionRadius = Mathf.CeilToInt(ViewRadius) + RetainedChunkPadding;
+        var releaseCoords = new List<Vector2Int>();
+
+        foreach (var pair in m_chunks)
+        {
+            if (pair.Value.IsCombiningMesh) continue;
+
+            var delta = pair.Key - m_playerChunk;
+            if (Mathf.Max(Mathf.Abs(delta.x), Mathf.Abs(delta.y)) > retentionRadius)
+            {
+                releaseCoords.Add(pair.Key);
+            }
+        }
+
+        foreach (var coord in releaseCoords)
+        {
+            if (m_chunks.TryGetValue(coord, out var chunk) == false) continue;
+
+            ReleaseChunkContents(chunk);
+            m_pendingSpawnChunks.Remove(chunk);
+            m_chunks.Remove(coord);
+        }
+    }
+
+    private void ReleaseChunkContents(Chunk chunk)
+    {
+        if (chunk?.ChunkObject == null) return;
+
+        var enemies = chunk.ChunkObject.GetComponentsInChildren<EnemyController>(true);
+        foreach (var enemy in enemies)
+        {
+            GameLoop?.EnemySpawner?.DestroyEnemy(enemy);
+        }
+
+        var npcs = chunk.ChunkObject.GetComponentsInChildren<NPCBase>(true);
+        foreach (var npc in npcs)
+        {
+            GameLoop?.NPCSpawner?.DestroyNPC(npc);
+        }
+
+        foreach (var combinedObject in chunk.CombinedMeshObjects)
+        {
+            if (combinedObject == null) continue;
+
+            var filter = combinedObject.GetComponent<MeshFilter>();
+            if (filter != null && filter.sharedMesh != null)
+            {
+                Destroy(filter.sharedMesh);
+            }
+        }
+
+        Destroy(chunk.ChunkObject);
     }
 
     private Vector2Int GetPlayerChunkCoord(Vector3 position)

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -21,11 +21,21 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     private Vector2Int m_playerChunk;
     private readonly Dictionary<Vector2Int, Chunk> m_chunks = new();
+    private readonly HashSet<Vector2Int> m_loadedCoords = new();
     private Vector2Int m_lastPlayerChunk;
+    private bool m_hasPlayerChunk;
     private bool m_hasLastPlayerChunk;
     private bool m_isUpdatingNavMesh;
     private bool m_pendingNavMeshUpdate;
+    private bool m_isNavMeshUpdateQueued;
     private readonly HashSet<Chunk> m_pendingSpawnChunks = new();
+    private static readonly Vector2Int[] NeighborDirs =
+    {
+        Vector2Int.up,
+        Vector2Int.down,
+        Vector2Int.left,
+        Vector2Int.right
+    };
 
     [SerializeField] private NavMeshSurface m_surface;
 
@@ -57,13 +67,14 @@ public class ChunkManager : ManagerBase<ChunkManager>
     {
         if (Player == null || Generator == null || ChunkSize <= 0 || BlockSize.x <= 0 || BlockSize.z <= 0) return;
 
-        m_playerChunk = new Vector2Int(
-            Mathf.FloorToInt(Player.position.x / (ChunkSize * BlockSize.x)),
-            Mathf.FloorToInt(Player.position.z / (ChunkSize * BlockSize.z))
-        );
+        var nextPlayerChunk = GetPlayerChunkCoord(Player.position);
+        if (init == false && m_hasPlayerChunk && nextPlayerChunk == m_playerChunk) return;
+
+        m_playerChunk = nextPlayerChunk;
+        m_hasPlayerChunk = true;
 
         var range = Mathf.CeilToInt(ViewRadius + 2);
-        var loadedCoords = new HashSet<Vector2Int>();
+        m_loadedCoords.Clear();
         for (var i = -range; i < range; i++)
         {
             for (var j = -range; j < range; j++)
@@ -75,7 +86,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
                 if (init == false && inView)
                 {
                     LoadOrGenerateChunk(coord);
-                    loadedCoords.Add(coord);
+                    m_loadedCoords.Add(coord);
                 }
                 else
                 {
@@ -99,7 +110,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
         foreach (var pair in m_chunks)
         {
-            if (loadedCoords.Contains(pair.Key) == false)
+            if (m_loadedCoords.Contains(pair.Key) == false)
             {
                 pair.Value.Unload();
             }
@@ -128,7 +139,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
         {
             chunk.IsGenerateMonster = true;
             m_pendingSpawnChunks.Add(chunk);
-            UpdateMapRoutine().Forget();
+            RequestNavMeshUpdate();
         }
     }
 
@@ -144,15 +155,38 @@ public class ChunkManager : ManagerBase<ChunkManager>
         return chunk;
     }
 
+    private Vector2Int GetPlayerChunkCoord(Vector3 position)
+    {
+        return new Vector2Int(
+            Mathf.FloorToInt(position.x / (ChunkSize * BlockSize.x)),
+            Mathf.FloorToInt(position.z / (ChunkSize * BlockSize.z))
+        );
+    }
+
     private void NavUpdate()
     {
         if (m_hasLastPlayerChunk == false || m_playerChunk != m_lastPlayerChunk)
         {
-            UpdateMapRoutine().Forget();
+            RequestNavMeshUpdate();
         }
 
         m_lastPlayerChunk = m_playerChunk;
         m_hasLastPlayerChunk = true;
+    }
+
+    private void RequestNavMeshUpdate()
+    {
+        if (m_isNavMeshUpdateQueued) return;
+
+        m_isNavMeshUpdateQueued = true;
+        RunQueuedNavMeshUpdate().Forget();
+    }
+
+    private async UniTaskVoid RunQueuedNavMeshUpdate()
+    {
+        await UniTask.Yield();
+        m_isNavMeshUpdateQueued = false;
+        UpdateMapRoutine().Forget();
     }
 
     public async UniTaskVoid UpdateMapRoutine()
@@ -259,7 +293,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
         m_isUpdatingNavMesh = false;
         if (m_pendingNavMeshUpdate)
         {
-            UpdateMapRoutine().Forget();
+            RequestNavMeshUpdate();
             return;
         }
 
@@ -323,7 +357,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
         {
             m_surface.BuildNavMesh();
             yield return new WaitForSeconds(3f);
-            UpdateMapRoutine().Forget();
+            RequestNavMeshUpdate();
         }
     }
 
@@ -384,15 +418,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     private void ConnectNeighborChunk(Vector2Int chunkCoord)
     {
-        Vector2Int[] dirs =
-        {
-            Vector2Int.up,
-            Vector2Int.down,
-            Vector2Int.left,
-            Vector2Int.right
-        };
-
-        foreach (var dir in dirs)
+        foreach (var dir in NeighborDirs)
         {
             var neighborCoord = chunkCoord + dir;
             if (m_chunks.ContainsKey(neighborCoord) == false) continue;

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -248,10 +248,15 @@ public class MapGenerator : MonoBehaviour
         var wallMask = wallLayer >= 0 ? 1 << wallLayer : Physics.DefaultRaycastLayers;
         var rayDistance = (thickness * 2 + 1) * blockFrontSize;
 
+        Physics.SyncTransforms();
+
         if (Physics.Raycast(startTunnelOffset, rayDir, out var hit, rayDistance, wallMask))
         {
             startTunnelOffset = hit.transform.position - rayDir * thickness * blockFrontSize;
         }
+
+        Vector3 bestStartPos = Vector3.zero;
+        RaycastHit[] bestHits = null;
 
         foreach (var wallIndex in tunnelList)
         {
@@ -259,20 +264,46 @@ public class MapGenerator : MonoBehaviour
             var hits = Physics.RaycastAll(startPos, rayDir, rayDistance, wallMask);
             if (hits.Length == 0 || hits.Length > thickness) continue;
 
-            Debug.DrawRay(startPos, rayDir * rayDistance, Color.red, 3000f);
+            CarveTunnel(startPos, rayDir, rayDistance, hits, parent);
+            return true;
+        }
 
-            foreach (var hitInfo in hits)
+        foreach (var wallIndex in tunnelList)
+        {
+            var startPos = startTunnelOffset + wallDir * blockRightSize * wallIndex;
+            var hits = Physics.RaycastAll(startPos, rayDir, rayDistance, wallMask);
+            if (hits.Length == 0) continue;
+
+            if (bestHits == null || hits.Length < bestHits.Length)
             {
-                var pos = new Vector3(hitInfo.transform.position.x, 0, hitInfo.transform.position.z);
-                CreateTunnelFloor(pos, parent);
-                Destroy(hitInfo.collider.gameObject);
+                bestStartPos = startPos;
+                bestHits = hits;
             }
+        }
 
-            CreateTunnelGates(startPos, rayDir, hits.Length * blockFrontSize, parent);
+        if (bestHits != null)
+        {
+            CarveTunnel(bestStartPos, rayDir, rayDistance, bestHits, parent);
             return true;
         }
 
         return false;
+    }
+
+    private void CarveTunnel(Vector3 startPos, Vector3 rayDir, float rayDistance, RaycastHit[] hits, Transform parent)
+    {
+        Debug.DrawRay(startPos, rayDir * rayDistance, Color.red, 3000f);
+
+        var tunnelLength = 0f;
+        foreach (var hitInfo in hits.OrderBy(hitInfo => hitInfo.distance))
+        {
+            var pos = new Vector3(hitInfo.transform.position.x, 0, hitInfo.transform.position.z);
+            CreateTunnelFloor(pos, parent);
+            tunnelLength = Mathf.Max(tunnelLength, hitInfo.distance);
+            Destroy(hitInfo.collider.gameObject);
+        }
+
+        CreateTunnelGates(startPos, rayDir, tunnelLength, parent);
     }
 
     private void CreateTunnelFloor(Vector3 pos, Transform parent)

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Random = UnityEngine.Random;
@@ -14,13 +15,26 @@ public class MapGenerator : MonoBehaviour
     }
 
     public List<TileSst> Tiles;
+    public bool IsReady { get; private set; }
 
     private Dictionary<TileType, TileSst> m_tiles;
     private readonly Collider[] m_overlapBuffer = new Collider[64];
+    private const int PoolWarmupPerFrame = 64;
+    private const int TilePlacementsPerFrame = 64;
 
     private void Awake()
     {
         InitTiles();
+    }
+
+    private IEnumerator Start()
+    {
+        foreach (var tile in m_tiles.Values)
+        {
+            yield return tile.pool.Warmup(PoolWarmupPerFrame);
+        }
+
+        IsReady = true;
     }
 
     private void InitTiles()
@@ -34,20 +48,25 @@ public class MapGenerator : MonoBehaviour
         {
             if (t.pool == null) continue;
 
-            t.pool.Init();
+            t.pool.Init(null, 0);
             m_tiles[t.type] = t;
-            StartCoroutine(t.pool.AutoCreateObjectPerFrame());
         }
     }
 
-    public void GenerateChunk(RectInt bounds, Transform parent, int minRoomSize, Vector3Int blockSize, out List<Vector3> floorPosData)
+    public IEnumerator GenerateChunkRoutine(
+        RectInt bounds,
+        Transform parent,
+        int minRoomSize,
+        Vector3Int blockSize,
+        Action<List<Vector3>> onComplete)
     {
         InitTiles();
 
         var width = bounds.width;
         var height = bounds.height;
         var mapData = new TileType[width, height];
-        floorPosData = new List<Vector3>();
+        var floorPosData = new List<Vector3>();
+        var placementCount = 0;
 
         var root = new BSPNode(new RectInt(0, 0, width, height));
         root.Split(minRoomSize);
@@ -81,6 +100,7 @@ public class MapGenerator : MonoBehaviour
                     obj.parent = parent;
                     obj.position = pos;
                     floorPosData.Add(pos);
+                    placementCount++;
                 }
 
                 if (m_tiles.TryGetValue(TileType.Celling, out var ceiling))
@@ -88,6 +108,13 @@ public class MapGenerator : MonoBehaviour
                     var obj = ceiling.pool.GetObject();
                     obj.position = pos + ceiling.offset;
                     obj.parent = parent;
+                    placementCount++;
+                }
+
+                if (placementCount >= TilePlacementsPerFrame)
+                {
+                    placementCount = 0;
+                    yield return null;
                 }
             }
         }
@@ -104,9 +131,15 @@ public class MapGenerator : MonoBehaviour
                     var obj = wall.pool.GetObject();
                     obj.position = pos + wall.offset;
                     obj.parent = parent;
+                    placementCount++;
                 }
 
                 mapData[x, y] = TileType.Wall;
+                if (placementCount >= TilePlacementsPerFrame)
+                {
+                    placementCount = 0;
+                    yield return null;
+                }
             }
         }
 
@@ -114,9 +147,20 @@ public class MapGenerator : MonoBehaviour
         {
             for (var y = 0; y < height; y++)
             {
-                CreatePillar(mapData, x, y, ToWorldPosition(bounds, x, y, blockSize), parent);
+                if (CreatePillar(mapData, x, y, ToWorldPosition(bounds, x, y, blockSize), parent))
+                {
+                    placementCount++;
+                }
+
+                if (placementCount >= TilePlacementsPerFrame)
+                {
+                    placementCount = 0;
+                    yield return null;
+                }
             }
         }
+
+        onComplete?.Invoke(floorPosData);
     }
 
     private Vector3 ToWorldPosition(RectInt bounds, int x, int y, Vector3Int blockSize)
@@ -129,9 +173,9 @@ public class MapGenerator : MonoBehaviour
         return x >= 0 && y >= 0 && x < map.GetLength(0) && y < map.GetLength(1);
     }
 
-    private void CreatePillar(TileType[,] map, int x, int y, Vector3 wallPos, Transform parent)
+    private bool CreatePillar(TileType[,] map, int x, int y, Vector3 wallPos, Transform parent)
     {
-        if (x < 1 || y > map.GetLength(1) - 2) return;
+        if (x < 1 || y > map.GetLength(1) - 2) return false;
 
         var left = map[x - 1, y] == TileType.Wall;
         var up = map[x, y + 1] == TileType.Wall;
@@ -147,7 +191,10 @@ public class MapGenerator : MonoBehaviour
             var obj = pillar.pool.GetObject();
             obj.position = wallPos + pillar.offset;
             obj.parent = parent;
+            return true;
         }
+
+        return false;
     }
 
     private void ConnectRooms(BSPNode node, TileType[,] mapData)

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -197,30 +197,12 @@ public class MapGenerator : MonoBehaviour
     public bool TryConnectChunks(Chunk chunk, Chunk neighborChunk, Vector2Int chunkToNeighborDir, Vector3Int blockSize)
     {
         if (chunk == null || neighborChunk == null || blockSize.x <= 0 || blockSize.z <= 0) return false;
+        if (chunkToNeighborDir != Vector2Int.up &&
+            chunkToNeighborDir != Vector2Int.down &&
+            chunkToNeighborDir != Vector2Int.left &&
+            chunkToNeighborDir != Vector2Int.right) return false;
 
-        var edgeStart = GetChunkEdgeStart(chunk, blockSize, chunkToNeighborDir);
-
-        if (chunkToNeighborDir == Vector2Int.up || chunkToNeighborDir == Vector2Int.down)
-        {
-            if (TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.right, blockSize, 2, chunk.Bounds.width, chunk.ChunkObject.transform))
-            {
-                return true;
-            }
-
-            return TryCarveFallbackTunnel(chunk, neighborChunk, chunkToNeighborDir, blockSize);
-        }
-
-        if (chunkToNeighborDir == Vector2Int.left || chunkToNeighborDir == Vector2Int.right)
-        {
-            if (TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.forward, blockSize, 2, chunk.Bounds.height, chunk.ChunkObject.transform))
-            {
-                return true;
-            }
-
-            return TryCarveFallbackTunnel(chunk, neighborChunk, chunkToNeighborDir, blockSize);
-        }
-
-        return false;
+        return TryCarveFallbackTunnel(chunk, neighborChunk, chunkToNeighborDir, blockSize);
     }
 
     private bool TryCarveFallbackTunnel(Chunk chunk, Chunk neighborChunk, Vector2Int dir, Vector3Int blockSize)

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
-
-public class MapGenerator: MonoBehaviour
+public class MapGenerator : MonoBehaviour
 {
     [Serializable]
     public struct TileSst
@@ -14,16 +13,27 @@ public class MapGenerator: MonoBehaviour
         public ObjectPool<Transform> pool;
         public Vector3 offset;
     }
+
     public List<TileSst> Tiles;
 
     private Dictionary<TileType, TileSst> m_tiles;
 
-
     private void Awake()
     {
-        m_tiles = new();
+        InitTiles();
+    }
+
+    private void InitTiles()
+    {
+        if (m_tiles != null) return;
+
+        m_tiles = new Dictionary<TileType, TileSst>();
+        if (Tiles == null) return;
+
         foreach (var t in Tiles)
         {
+            if (t.pool == null) continue;
+
             t.pool.Init();
             m_tiles[t.type] = t;
             StartCoroutine(t.pool.AutoCreateObjectPerFrame());
@@ -32,104 +42,107 @@ public class MapGenerator: MonoBehaviour
 
     public void GenerateChunk(RectInt bounds, Transform parent, int minRoomSize, Vector3Int blockSize, out List<Vector3> floorPosData)
     {
-        int width = bounds.width;
-        int height = bounds.height;
+        InitTiles();
+
+        var width = bounds.width;
+        var height = bounds.height;
         var mapData = new TileType[width, height];
         floorPosData = new List<Vector3>();
 
-        BSPNode root = new BSPNode(new RectInt(0, 0, width, height));
+        var root = new BSPNode(new RectInt(0, 0, width, height));
         root.Split(minRoomSize);
 
-        List<RectInt> rooms = root.GetRooms();
-
-        // 방 생성
-        foreach (var room in rooms)
+        foreach (var room in root.GetRooms())
         {
-            for (int x = room.xMin + 1; x < room.xMax - 1; x++)
+            for (var x = room.xMin + 1; x < room.xMax - 1; x++)
             {
-                for (int y = room.yMin + 1; y < room.yMax - 1; y++)
+                for (var y = room.yMin + 1; y < room.yMax - 1; y++)
                 {
-                    mapData[x, y] = TileType.Floor;
+                    if (IsInside(mapData, x, y))
+                    {
+                        mapData[x, y] = TileType.Floor;
+                    }
                 }
             }
         }
 
-        // 복도 연결
         ConnectRooms(root, mapData);
 
-
-        // 바닥 생성
-        for (int x = 0; x < width; x++)
+        for (var x = 0; x < width; x++)
         {
-            for (int y = 0; y < height; y++)
+            for (var y = 0; y < height; y++)
             {
-                if (mapData[x, y] == TileType.Floor)
+                if (mapData[x, y] != TileType.Floor) continue;
+
+                var pos = ToWorldPosition(bounds, x, y, blockSize);
+                if (m_tiles.TryGetValue(TileType.Floor, out var floor))
                 {
-                    Vector3 pos = new Vector3(bounds.x + (x*blockSize.x), 0, bounds.y + (y*blockSize.z));
-                    if (m_tiles.TryGetValue(TileType.Floor, out var floor))
-                    {
-                        Transform obj = floor.pool.GetObject();
-                        obj.parent = parent;
-                        obj.position = pos;
-                        floorPosData.Add(pos);
-                    }
-                    if (m_tiles.TryGetValue(TileType.Celling, out var ceiling))
-                    {
-                        var obj = ceiling.pool.GetObject();
-                        obj.position = pos + ceiling.offset;
-                        obj.parent = parent;
-                    }
+                    var obj = floor.pool.GetObject();
+                    obj.parent = parent;
+                    obj.position = pos;
+                    floorPosData.Add(pos);
+                }
+
+                if (m_tiles.TryGetValue(TileType.Celling, out var ceiling))
+                {
+                    var obj = ceiling.pool.GetObject();
+                    obj.position = pos + ceiling.offset;
+                    obj.parent = parent;
                 }
             }
         }
 
-        // 비어있는 구역은 임의의 벽으로 메우기
-        for (int x = 0; x < width; x++)
+        for (var x = 0; x < width; x++)
         {
-            for (int y = 0; y < height; y++)
+            for (var y = 0; y < height; y++)
             {
-                if (mapData[x, y] == TileType.Empty)
+                if (mapData[x, y] != TileType.Empty) continue;
+
+                var pos = ToWorldPosition(bounds, x, y, blockSize);
+                if (m_tiles.TryGetValue(TileType.Wall, out var wall))
                 {
-                    Vector3 pos = new Vector3(bounds.x + (x * blockSize.x), 0, bounds.y + (y * blockSize.z));
-                    if (m_tiles.TryGetValue(TileType.Wall, out var wall))
-                    {
-                        var obj = wall.pool.GetObject();
-                        obj.position = pos + wall.offset;
-                        obj.parent = parent;
-                    }
-                    mapData[x, y] = TileType.Wall;
+                    var obj = wall.pool.GetObject();
+                    obj.position = pos + wall.offset;
+                    obj.parent = parent;
                 }
+
+                mapData[x, y] = TileType.Wall;
             }
         }
 
-        for (int x = 0; x < width; x++)
+        for (var x = 0; x < width; x++)
         {
-            for (int y = 0; y < height; y++)
+            for (var y = 0; y < height; y++)
             {
-                Vector3 pos = new Vector3(bounds.x + (x * blockSize.x), 0, bounds.y + (y * blockSize.z));
-                CreatePillar(mapData, x, y, pos, parent);
+                CreatePillar(mapData, x, y, ToWorldPosition(bounds, x, y, blockSize), parent);
             }
         }
     }
 
+    private Vector3 ToWorldPosition(RectInt bounds, int x, int y, Vector3Int blockSize)
+    {
+        return new Vector3(bounds.x + x * blockSize.x, 0, bounds.y + y * blockSize.z);
+    }
+
+    private bool IsInside(TileType[,] map, int x, int y)
+    {
+        return x >= 0 && y >= 0 && x < map.GetLength(0) && y < map.GetLength(1);
+    }
 
     private void CreatePillar(TileType[,] map, int x, int y, Vector3 wallPos, Transform parent)
     {
-        // 1x1부터 좌상단 4개의 블럭을 검사하도록
         if (x < 1 || y > map.GetLength(1) - 2) return;
 
-        // 규칙: [좌,상,좌상] , [상], [좌]에 블럭이 있는 경우를 제외하면 좌상단 모서리에 기둥 필요
-        // 예외: x,y에 벽이 없는 경우는 위의 경우에서 기둥 필요
-        // 예외2: 좌상단만 벽이 있는 경우, x,y의 벽 유무와 상관없이 기둥 필요
-        bool left = map[x-1, y] == TileType.Wall;
-        bool up = map[x, y + 1] == TileType.Wall;
-        bool leftUp = map[x - 1, y + 1] == TileType.Wall;
-        bool exceptions = (left && up && leftUp) || (!left && up && !leftUp) || (left && !up && !leftUp);
-        bool exceptions2 = !left && !up && leftUp;
+        var left = map[x - 1, y] == TileType.Wall;
+        var up = map[x, y + 1] == TileType.Wall;
+        var leftUp = map[x - 1, y + 1] == TileType.Wall;
+        var exceptions = (left && up && leftUp) || (!left && up && !leftUp) || (left && !up && !leftUp);
+        var exceptions2 = !left && !up && leftUp;
 
-        bool res = exceptions ^ (map[x, y] == TileType.Wall);
-        res |= exceptions2;
-        if (res && m_tiles.TryGetValue(TileType.Pillar, out var pillar))
+        var shouldCreate = exceptions ^ (map[x, y] == TileType.Wall);
+        shouldCreate |= exceptions2;
+
+        if (shouldCreate && m_tiles.TryGetValue(TileType.Pillar, out var pillar))
         {
             var obj = pillar.pool.GetObject();
             obj.position = wallPos + pillar.offset;
@@ -139,172 +152,168 @@ public class MapGenerator: MonoBehaviour
 
     private void ConnectRooms(BSPNode node, TileType[,] mapData)
     {
-        if (node.IsLeaf) return;
+        if (node == null || node.IsLeaf || node.Left == null || node.Right == null) return;
 
-        Vector2Int centerA = node.Left.GetRoomCenter();
-        Vector2Int centerB = node.Right.GetRoomCenter();
+        var centerA = node.Left.GetRoomCenter();
+        var centerB = node.Right.GetRoomCenter();
 
         if (Random.value > 0.5f)
         {
-            for (int x = Mathf.Min(centerA.x, centerB.x); x <= Mathf.Max(centerA.x, centerB.x); x++)
-                mapData[x, centerA.y] = TileType.Floor;
-            for (int y = Mathf.Min(centerA.y, centerB.y); y <= Mathf.Max(centerA.y, centerB.y); y++)
-                mapData[centerB.x, y] = TileType.Floor;
+            CarveHorizontal(mapData, centerA.x, centerB.x, centerA.y);
+            CarveVertical(mapData, centerA.y, centerB.y, centerB.x);
         }
         else
         {
-            for (int y = Mathf.Min(centerA.y, centerB.y); y <= Mathf.Max(centerA.y, centerB.y); y++)
-                mapData[centerA.x, y] = TileType.Floor;
-            for (int x = Mathf.Min(centerA.x, centerB.x); x <= Mathf.Max(centerA.x, centerB.x); x++)
-                mapData[x, centerB.y] = TileType.Floor;
+            CarveVertical(mapData, centerA.y, centerB.y, centerA.x);
+            CarveHorizontal(mapData, centerA.x, centerB.x, centerB.y);
         }
 
         ConnectRooms(node.Left, mapData);
         ConnectRooms(node.Right, mapData);
     }
 
-    public bool TryConnectChunks(Chunk a, Vector2Int aTobDir, Vector3Int blockSize, Transform parent)
+    private void CarveHorizontal(TileType[,] mapData, int fromX, int toX, int y)
     {
-        // 이미 들어오는 인자는 인접한 청크임을 보장 + 인접한 면의 길이는 동일
-        var midEdge = GetMinEdge(a.Bounds, blockSize, aTobDir);
-        // 가장자리의 중심좌표를 미리 구해서 전달
-        if (aTobDir == Vector2Int.up || aTobDir == Vector2Int.down)
+        for (var x = Mathf.Min(fromX, toX); x <= Mathf.Max(fromX, toX); x++)
         {
-            return TryBreakSlimWall(midEdge ,aTobDir, Vector3.right, blockSize, 2 , a.Bounds.width, parent);
-        }
-        else if (aTobDir == Vector2Int.left || aTobDir == Vector2Int.right)
-        {
-            return TryBreakSlimWall(midEdge, aTobDir, Vector3.forward, blockSize, 2, a.Bounds.height, parent);
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    private Vector2 GetMinEdge(RectInt bound, Vector3Int blockSize ,Vector2Int turnelDir)
-    {
-        // 벽 방향은 Right or Up
-        if (turnelDir == Vector2Int.up)
-        {
-            return new Vector2(bound.xMin, bound.yMin * blockSize.x);
-        }
-        else if (turnelDir == Vector2Int.down)
-        {
-            return new Vector2(bound.xMin, bound.yMin);
-        }
-        else if (turnelDir == Vector2Int.left)
-        {
-            return new Vector2(bound.xMin, bound.yMin);
-        }
-        else if (turnelDir == Vector2Int.right)
-        {
-            return new Vector2(bound.xMin * blockSize.z , bound.yMin);
-        }
-        else
-        {
-            return Vector2Int.zero;
-        }
-    }
-
-    private bool TryBreakSlimWall(Vector2 minEdge,Vector2Int turnelDir, Vector3 wallDir, Vector3Int blockSize, int thickness, int maxLength,Transform parent)
-    {
-        List<int> turnelList = Enumerable.Range(0, maxLength).ToList();
-        turnelList = turnelList.OrderBy(x => Random.value).ToList();
-
-        float blockFrontSize = 0;
-        float blockRightSize = 0;
-
-        if (wallDir == Vector3.right)
-        {
-            blockFrontSize = blockSize.z;
-            blockRightSize = blockSize.x;
-        }
-        else
-        {
-            blockFrontSize = blockSize.x;
-            blockRightSize = blockSize.z;
-        }
-        
-        var startXY = minEdge - turnelDir * thickness;
-        var startTurnelOffset = new Vector3(startXY.x, 0 ,startXY.y);
-        var rayDir = new Vector3(turnelDir.x, 0, turnelDir.y);
-        if (m_tiles.TryGetValue(TileType.Wall, out var wall))
-            startTurnelOffset += wall.offset.y * Vector3.up;
-
-        // 벽 위치에 맞게 시작위치 보정
-        if (Physics.Raycast(startTurnelOffset, rayDir, out var hit, (thickness * 2 + 1) * blockFrontSize, 1 << LayerMask.NameToLayer("Wall")))
-            startTurnelOffset = hit.transform.position - rayDir * thickness * blockFrontSize;
-
-        // 랜덤으로 벽 가장자리를 따라 조건에 부합하는 가장자리 좌표 확인
-        // 일정 오프셋 뒤에서 터널 뚫는 방향으로 RaycastAll로 벽의 개수 검사
-        foreach (var wall_Idx in turnelList)
-        {
-            var startPos = startTurnelOffset + wallDir * blockRightSize * wall_Idx;
-            var res = Physics.RaycastAll(startPos, rayDir, (thickness * 2 + 1) * blockFrontSize, 1 << LayerMask.NameToLayer("Wall"));
-            // 벽이 일정두께 이하인 경우에만 터널 뚫기
-            if (res.Length <= thickness)
+            if (IsInside(mapData, x, y))
             {
-                Debug.DrawRay(startPos, rayDir * (thickness * 2 + 1) * blockFrontSize, Color.red, 3000f);
-
-                foreach (var obj in res)
-                {
-                    var pos = new Vector3(obj.transform.position.x, 0 , obj.transform.position.z);
-                    if (m_tiles.TryGetValue(TileType.Floor, out var floor))
-                    {
-                        var obj2 = floor.pool.GetObject();
-                        obj2.position = pos;
-                        obj2.parent = parent;
-                    }
-                    if (m_tiles.TryGetValue(TileType.Celling, out var ceiling))
-                    {
-                        var obj2 = ceiling.pool.GetObject();
-                        obj2.position = pos + ceiling.offset;
-                        obj2.parent = parent;
-                    }
-                    Destroy(obj.collider.gameObject);
-                }
-                // 없어진 자리에는 아치형 문 생성
-                // 회전 및 축 보정
-                if (m_tiles.TryGetValue(TileType.Gate, out var gate))
-                {
-                    Vector3 forward = rayDir;
-                    Vector3 right = Vector3.Cross(Vector3.up, forward);
-                    Vector3 up = Vector3.up;
-
-                    //// forward각이 서로 90차이나는 경우, right의 방향을 서로 뒤집어야 함
-                    //// 다른 그렇지 않은 경우에 서로 x 오프셋 방향 반대로 작용
-                    //if (Mathf.Abs(forward.x) > 0.5f && Mathf.Abs(forward.z) < 0.5f)
-                    //{
-                    //    right = -right;
-                    //}
-
-                    var look = new Vector3(rayDir.x, startPos.y + gate.offset.y, rayDir.z);
-                    Quaternion rotation = Quaternion.LookRotation(rayDir);
-
-                    var GateOffset = gate.offset;
-                    Vector3 rotatedPos = startPos
-                                        + GateOffset.z * forward
-                                        + GateOffset.x * right
-                                        + GateOffset.y * up;
-
-                    var gate1 = gate.pool.GetObject();
-                    gate1.position = rotatedPos;
-                    gate1.rotation = rotation;
-                    gate1.parent = parent;
-
-                    var gate2 = gate.pool.GetObject();
-                    gate2.position = rotatedPos + res.Length * blockFrontSize * rayDir;
-                    gate2.rotation = rotation;
-                    gate2.parent = parent;
-
-                    //Debug.DrawRay(rotatedPos, forward * 2f, Color.red, 1000f);
-                    //Debug.DrawRay(rotatedPos, right * 2f, Color.green, 1000f);   // x방향
-                }
-                
-                return true;
+                mapData[x, y] = TileType.Floor;
             }
         }
+    }
+
+    private void CarveVertical(TileType[,] mapData, int fromY, int toY, int x)
+    {
+        for (var y = Mathf.Min(fromY, toY); y <= Mathf.Max(fromY, toY); y++)
+        {
+            if (IsInside(mapData, x, y))
+            {
+                mapData[x, y] = TileType.Floor;
+            }
+        }
+    }
+
+    public bool TryConnectChunks(Chunk chunk, Vector2Int chunkToNeighborDir, Vector3Int blockSize, Transform parent)
+    {
+        if (chunk == null || parent == null || blockSize.x <= 0 || blockSize.z <= 0) return false;
+
+        var edgeStart = GetChunkEdgeStart(chunk, blockSize, chunkToNeighborDir);
+
+        if (chunkToNeighborDir == Vector2Int.up || chunkToNeighborDir == Vector2Int.down)
+        {
+            return TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.right, blockSize, 2, chunk.Bounds.width, parent);
+        }
+
+        if (chunkToNeighborDir == Vector2Int.left || chunkToNeighborDir == Vector2Int.right)
+        {
+            return TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.forward, blockSize, 2, chunk.Bounds.height, parent);
+        }
+
         return false;
+    }
+
+    private Vector2 GetChunkEdgeStart(Chunk chunk, Vector3Int blockSize, Vector2Int tunnelDir)
+    {
+        var minX = chunk.ChunkObject.transform.position.x;
+        var minZ = chunk.ChunkObject.transform.position.z;
+        var maxX = minX + chunk.Bounds.width * blockSize.x;
+        var maxZ = minZ + chunk.Bounds.height * blockSize.z;
+
+        if (tunnelDir == Vector2Int.up) return new Vector2(minX, maxZ);
+        if (tunnelDir == Vector2Int.down) return new Vector2(minX, minZ);
+        if (tunnelDir == Vector2Int.left) return new Vector2(minX, minZ);
+        if (tunnelDir == Vector2Int.right) return new Vector2(maxX, minZ);
+
+        return new Vector2(minX, minZ);
+    }
+
+    private bool TryBreakSlimWall(Vector2 minEdge, Vector2Int tunnelDir, Vector3 wallDir, Vector3Int blockSize, int thickness, int maxLength, Transform parent)
+    {
+        InitTiles();
+
+        var tunnelList = Enumerable.Range(0, maxLength).OrderBy(_ => Random.value).ToList();
+        var blockFrontSize = wallDir == Vector3.right ? blockSize.z : blockSize.x;
+        var blockRightSize = wallDir == Vector3.right ? blockSize.x : blockSize.z;
+        var rayDir = new Vector3(tunnelDir.x, 0, tunnelDir.y);
+        var startXY = minEdge - (Vector2)tunnelDir * (thickness * blockFrontSize);
+        var startTunnelOffset = new Vector3(startXY.x, 0, startXY.y);
+
+        if (m_tiles.TryGetValue(TileType.Wall, out var wall))
+        {
+            startTunnelOffset += wall.offset.y * Vector3.up;
+        }
+
+        var wallLayer = LayerMask.NameToLayer("Wall");
+        var wallMask = wallLayer >= 0 ? 1 << wallLayer : Physics.DefaultRaycastLayers;
+        var rayDistance = (thickness * 2 + 1) * blockFrontSize;
+
+        if (Physics.Raycast(startTunnelOffset, rayDir, out var hit, rayDistance, wallMask))
+        {
+            startTunnelOffset = hit.transform.position - rayDir * thickness * blockFrontSize;
+        }
+
+        foreach (var wallIndex in tunnelList)
+        {
+            var startPos = startTunnelOffset + wallDir * blockRightSize * wallIndex;
+            var hits = Physics.RaycastAll(startPos, rayDir, rayDistance, wallMask);
+            if (hits.Length == 0 || hits.Length > thickness) continue;
+
+            Debug.DrawRay(startPos, rayDir * rayDistance, Color.red, 3000f);
+
+            foreach (var hitInfo in hits)
+            {
+                var pos = new Vector3(hitInfo.transform.position.x, 0, hitInfo.transform.position.z);
+                CreateTunnelFloor(pos, parent);
+                Destroy(hitInfo.collider.gameObject);
+            }
+
+            CreateTunnelGates(startPos, rayDir, hits.Length * blockFrontSize, parent);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void CreateTunnelFloor(Vector3 pos, Transform parent)
+    {
+        if (m_tiles.TryGetValue(TileType.Floor, out var floor))
+        {
+            var obj = floor.pool.GetObject();
+            obj.position = pos;
+            obj.parent = parent;
+        }
+
+        if (m_tiles.TryGetValue(TileType.Celling, out var ceiling))
+        {
+            var obj = ceiling.pool.GetObject();
+            obj.position = pos + ceiling.offset;
+            obj.parent = parent;
+        }
+    }
+
+    private void CreateTunnelGates(Vector3 startPos, Vector3 rayDir, float tunnelLength, Transform parent)
+    {
+        if (m_tiles.TryGetValue(TileType.Gate, out var gate) == false) return;
+
+        var forward = rayDir;
+        var right = Vector3.Cross(Vector3.up, forward);
+        var up = Vector3.up;
+        var rotation = Quaternion.LookRotation(rayDir);
+        var gateOffset = gate.offset;
+        var rotatedPos = startPos
+                         + gateOffset.z * forward
+                         + gateOffset.x * right
+                         + gateOffset.y * up;
+
+        var gate1 = gate.pool.GetObject();
+        gate1.position = rotatedPos;
+        gate1.rotation = rotation;
+        gate1.parent = parent;
+
+        var gate2 = gate.pool.GetObject();
+        gate2.position = rotatedPos + tunnelLength * rayDir;
+        gate2.rotation = rotation;
+        gate2.parent = parent;
     }
 }

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using Random = UnityEngine.Random;
 
@@ -17,6 +16,7 @@ public class MapGenerator : MonoBehaviour
     public List<TileSst> Tiles;
 
     private Dictionary<TileType, TileSst> m_tiles;
+    private readonly Collider[] m_overlapBuffer = new Collider[64];
 
     private void Awake()
     {
@@ -237,27 +237,49 @@ public class MapGenerator : MonoBehaviour
     private Vector3 GetEdgeFloor(Chunk chunk, Vector2Int dir)
     {
         var floors = chunk.floorPosData;
+        var best = floors[0];
+        var selected = best;
+        var selectedCount = 1;
 
-        if (dir == Vector2Int.up)
+        for (var i = 1; i < floors.Count; i++)
         {
-            var maxZ = floors.Max(pos => pos.z);
-            return floors.Where(pos => Mathf.Approximately(pos.z, maxZ)).OrderBy(_ => Random.value).First();
+            var pos = floors[i];
+            if (IsCloserToEdge(pos, best, dir))
+            {
+                best = pos;
+                selected = pos;
+                selectedCount = 1;
+                continue;
+            }
+
+            if (IsSameEdge(pos, best, dir) == false) continue;
+
+            selectedCount++;
+            if (Random.Range(0, selectedCount) == 0)
+            {
+                selected = pos;
+            }
         }
 
-        if (dir == Vector2Int.down)
+        return selected;
+    }
+
+    private bool IsCloserToEdge(Vector3 candidate, Vector3 currentBest, Vector2Int dir)
+    {
+        if (dir == Vector2Int.up) return candidate.z > currentBest.z;
+        if (dir == Vector2Int.down) return candidate.z < currentBest.z;
+        if (dir == Vector2Int.right) return candidate.x > currentBest.x;
+        return candidate.x < currentBest.x;
+    }
+
+    private bool IsSameEdge(Vector3 candidate, Vector3 currentBest, Vector2Int dir)
+    {
+        if (dir == Vector2Int.up || dir == Vector2Int.down)
         {
-            var minZ = floors.Min(pos => pos.z);
-            return floors.Where(pos => Mathf.Approximately(pos.z, minZ)).OrderBy(_ => Random.value).First();
+            return Mathf.Approximately(candidate.z, currentBest.z);
         }
 
-        if (dir == Vector2Int.right)
-        {
-            var maxX = floors.Max(pos => pos.x);
-            return floors.Where(pos => Mathf.Approximately(pos.x, maxX)).OrderBy(_ => Random.value).First();
-        }
-
-        var minX = floors.Min(pos => pos.x);
-        return floors.Where(pos => Mathf.Approximately(pos.x, minX)).OrderBy(_ => Random.value).First();
+        return Mathf.Approximately(candidate.x, currentBest.x);
     }
 
     private void CarveGridTunnel(Chunk chunk, Chunk neighborChunk, Vector3 start, Vector3 end, Vector2Int dir, Vector3Int blockSize)
@@ -328,10 +350,23 @@ public class MapGenerator : MonoBehaviour
         }
 
         owner.floorPosData ??= new List<Vector3>();
-        if (owner.floorPosData.Any(floor => Vector3.SqrMagnitude(floor - pos) < 0.01f) == false)
+        if (HasFloorData(owner.floorPosData, pos) == false)
         {
             owner.floorPosData.Add(pos);
         }
+    }
+
+    private bool HasFloorData(List<Vector3> floors, Vector3 pos)
+    {
+        for (var i = 0; i < floors.Count; i++)
+        {
+            if (Vector3.SqrMagnitude(floors[i] - pos) < 0.01f)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private bool HasTileAt(Vector3 pos, TileType tileType, Vector3Int blockSize)
@@ -340,7 +375,7 @@ public class MapGenerator : MonoBehaviour
         if (layer < 0) return false;
 
         var halfExtents = new Vector3(blockSize.x * 0.45f, 1.5f, blockSize.z * 0.45f);
-        return Physics.OverlapBox(pos + Vector3.up * 0.5f, halfExtents, Quaternion.identity, 1 << layer).Length > 0;
+        return Physics.OverlapBoxNonAlloc(pos + Vector3.up * 0.5f, halfExtents, m_overlapBuffer, Quaternion.identity, 1 << layer) > 0;
     }
 
     private bool ContainsWorldPosition(Chunk chunk, Vector3 pos, Vector3Int blockSize)
@@ -366,10 +401,10 @@ public class MapGenerator : MonoBehaviour
         if (mask == 0) mask = Physics.DefaultRaycastLayers;
 
         var halfExtents = new Vector3(blockSize.x * 0.45f, 1.5f, blockSize.z * 0.45f);
-        var hits = Physics.OverlapBox(pos + Vector3.up * 0.5f, halfExtents, Quaternion.identity, mask);
-        foreach (var hit in hits)
+        var hitCount = Physics.OverlapBoxNonAlloc(pos + Vector3.up * 0.5f, halfExtents, m_overlapBuffer, Quaternion.identity, mask);
+        for (var i = 0; i < hitCount; i++)
         {
-            Destroy(hit.gameObject);
+            Destroy(m_overlapBuffer[i].gameObject);
         }
     }
 
@@ -392,7 +427,6 @@ public class MapGenerator : MonoBehaviour
     {
         InitTiles();
 
-        var tunnelList = Enumerable.Range(0, maxLength).OrderBy(_ => Random.value).ToList();
         var blockFrontSize = wallDir == Vector3.right ? blockSize.z : blockSize.x;
         var blockRightSize = wallDir == Vector3.right ? blockSize.x : blockSize.z;
         var rayDir = new Vector3(tunnelDir.x, 0, tunnelDir.y);
@@ -418,8 +452,10 @@ public class MapGenerator : MonoBehaviour
         Vector3 bestStartPos = Vector3.zero;
         RaycastHit[] bestHits = null;
 
-        foreach (var wallIndex in tunnelList)
+        var startIndex = Random.Range(0, maxLength);
+        for (var attempt = 0; attempt < maxLength; attempt++)
         {
+            var wallIndex = (startIndex + attempt) % maxLength;
             var startPos = startTunnelOffset + wallDir * blockRightSize * wallIndex;
             var hits = Physics.RaycastAll(startPos, rayDir, rayDistance, wallMask);
             if (hits.Length == 0 || hits.Length > thickness) continue;
@@ -428,8 +464,9 @@ public class MapGenerator : MonoBehaviour
             return true;
         }
 
-        foreach (var wallIndex in tunnelList)
+        for (var attempt = 0; attempt < maxLength; attempt++)
         {
+            var wallIndex = (startIndex + attempt) % maxLength;
             var startPos = startTunnelOffset + wallDir * blockRightSize * wallIndex;
             var hits = Physics.RaycastAll(startPos, rayDir, rayDistance, wallMask);
             if (hits.Length == 0) continue;
@@ -455,7 +492,8 @@ public class MapGenerator : MonoBehaviour
         Debug.DrawRay(startPos, rayDir * rayDistance, Color.red, 3000f);
 
         var tunnelLength = 0f;
-        foreach (var hitInfo in hits.OrderBy(hitInfo => hitInfo.distance))
+        Array.Sort(hits, (a, b) => a.distance.CompareTo(b.distance));
+        foreach (var hitInfo in hits)
         {
             var pos = new Vector3(hitInfo.transform.position.x, 0, hitInfo.transform.position.z);
             CreateTunnelFloor(pos, parent);

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -194,23 +194,183 @@ public class MapGenerator : MonoBehaviour
         }
     }
 
-    public bool TryConnectChunks(Chunk chunk, Vector2Int chunkToNeighborDir, Vector3Int blockSize, Transform parent)
+    public bool TryConnectChunks(Chunk chunk, Chunk neighborChunk, Vector2Int chunkToNeighborDir, Vector3Int blockSize)
     {
-        if (chunk == null || parent == null || blockSize.x <= 0 || blockSize.z <= 0) return false;
+        if (chunk == null || neighborChunk == null || blockSize.x <= 0 || blockSize.z <= 0) return false;
 
         var edgeStart = GetChunkEdgeStart(chunk, blockSize, chunkToNeighborDir);
 
         if (chunkToNeighborDir == Vector2Int.up || chunkToNeighborDir == Vector2Int.down)
         {
-            return TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.right, blockSize, 2, chunk.Bounds.width, parent);
+            if (TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.right, blockSize, 2, chunk.Bounds.width, chunk.ChunkObject.transform))
+            {
+                return true;
+            }
+
+            return TryCarveFallbackTunnel(chunk, neighborChunk, chunkToNeighborDir, blockSize);
         }
 
         if (chunkToNeighborDir == Vector2Int.left || chunkToNeighborDir == Vector2Int.right)
         {
-            return TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.forward, blockSize, 2, chunk.Bounds.height, parent);
+            if (TryBreakSlimWall(edgeStart, chunkToNeighborDir, Vector3.forward, blockSize, 2, chunk.Bounds.height, chunk.ChunkObject.transform))
+            {
+                return true;
+            }
+
+            return TryCarveFallbackTunnel(chunk, neighborChunk, chunkToNeighborDir, blockSize);
         }
 
         return false;
+    }
+
+    private bool TryCarveFallbackTunnel(Chunk chunk, Chunk neighborChunk, Vector2Int dir, Vector3Int blockSize)
+    {
+        if (chunk.floorPosData == null || neighborChunk.floorPosData == null) return false;
+        if (chunk.floorPosData.Count == 0 || neighborChunk.floorPosData.Count == 0) return false;
+
+        var start = GetEdgeFloor(chunk, dir);
+        var end = GetEdgeFloor(neighborChunk, -dir);
+        CarveGridTunnel(chunk, neighborChunk, start, end, dir, blockSize);
+        return true;
+    }
+
+    private Vector3 GetEdgeFloor(Chunk chunk, Vector2Int dir)
+    {
+        var floors = chunk.floorPosData;
+
+        if (dir == Vector2Int.up)
+        {
+            var maxZ = floors.Max(pos => pos.z);
+            return floors.Where(pos => Mathf.Approximately(pos.z, maxZ)).OrderBy(_ => Random.value).First();
+        }
+
+        if (dir == Vector2Int.down)
+        {
+            var minZ = floors.Min(pos => pos.z);
+            return floors.Where(pos => Mathf.Approximately(pos.z, minZ)).OrderBy(_ => Random.value).First();
+        }
+
+        if (dir == Vector2Int.right)
+        {
+            var maxX = floors.Max(pos => pos.x);
+            return floors.Where(pos => Mathf.Approximately(pos.x, maxX)).OrderBy(_ => Random.value).First();
+        }
+
+        var minX = floors.Min(pos => pos.x);
+        return floors.Where(pos => Mathf.Approximately(pos.x, minX)).OrderBy(_ => Random.value).First();
+    }
+
+    private void CarveGridTunnel(Chunk chunk, Chunk neighborChunk, Vector3 start, Vector3 end, Vector2Int dir, Vector3Int blockSize)
+    {
+        var current = start;
+        var forwardStep = new Vector3(dir.x * blockSize.x, 0f, dir.y * blockSize.z);
+        var sideStep = dir.x == 0 ? new Vector3(Mathf.Sign(end.x - start.x) * blockSize.x, 0f, 0f) : new Vector3(0f, 0f, Mathf.Sign(end.z - start.z) * blockSize.z);
+
+        CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+
+        if (dir.x == 0)
+        {
+            while (Mathf.Approximately(current.z, end.z) == false)
+            {
+                current += forwardStep;
+                if ((dir.y > 0 && current.z > end.z) || (dir.y < 0 && current.z < end.z))
+                {
+                    current.z = end.z;
+                }
+
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+            }
+
+            while (Mathf.Approximately(current.x, end.x) == false)
+            {
+                current += sideStep;
+                if ((sideStep.x > 0f && current.x > end.x) || (sideStep.x < 0f && current.x < end.x))
+                {
+                    current.x = end.x;
+                }
+
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+            }
+        }
+        else
+        {
+            while (Mathf.Approximately(current.x, end.x) == false)
+            {
+                current += forwardStep;
+                if ((dir.x > 0 && current.x > end.x) || (dir.x < 0 && current.x < end.x))
+                {
+                    current.x = end.x;
+                }
+
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+            }
+
+            while (Mathf.Approximately(current.z, end.z) == false)
+            {
+                current += sideStep;
+                if ((sideStep.z > 0f && current.z > end.z) || (sideStep.z < 0f && current.z < end.z))
+                {
+                    current.z = end.z;
+                }
+
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+            }
+        }
+    }
+
+    private void CarveTunnelCell(Chunk chunk, Chunk neighborChunk, Vector3 pos, Vector3Int blockSize)
+    {
+        var owner = ContainsWorldPosition(chunk, pos, blockSize) ? chunk : neighborChunk;
+        RemoveBlockingTiles(pos, blockSize);
+        if (HasTileAt(pos, TileType.Floor, blockSize) == false)
+        {
+            CreateTunnelFloor(pos, owner.ChunkObject.transform);
+        }
+
+        owner.floorPosData ??= new List<Vector3>();
+        if (owner.floorPosData.Any(floor => Vector3.SqrMagnitude(floor - pos) < 0.01f) == false)
+        {
+            owner.floorPosData.Add(pos);
+        }
+    }
+
+    private bool HasTileAt(Vector3 pos, TileType tileType, Vector3Int blockSize)
+    {
+        var layer = LayerMask.NameToLayer(tileType.ToString());
+        if (layer < 0) return false;
+
+        var halfExtents = new Vector3(blockSize.x * 0.45f, 1.5f, blockSize.z * 0.45f);
+        return Physics.OverlapBox(pos + Vector3.up * 0.5f, halfExtents, Quaternion.identity, 1 << layer).Length > 0;
+    }
+
+    private bool ContainsWorldPosition(Chunk chunk, Vector3 pos, Vector3Int blockSize)
+    {
+        var minX = chunk.Bounds.xMin;
+        var minZ = chunk.Bounds.yMin;
+        var maxX = chunk.Bounds.xMin + chunk.Bounds.width * blockSize.x;
+        var maxZ = chunk.Bounds.yMin + chunk.Bounds.height * blockSize.z;
+
+        return pos.x >= minX && pos.x < maxX && pos.z >= minZ && pos.z < maxZ;
+    }
+
+    private void RemoveBlockingTiles(Vector3 pos, Vector3Int blockSize)
+    {
+        var wallLayer = LayerMask.NameToLayer(TileType.Wall.ToString());
+        var pillarLayer = LayerMask.NameToLayer(TileType.Pillar.ToString());
+        var gateLayer = LayerMask.NameToLayer(TileType.Gate.ToString());
+        var mask = 0;
+
+        if (wallLayer >= 0) mask |= 1 << wallLayer;
+        if (pillarLayer >= 0) mask |= 1 << pillarLayer;
+        if (gateLayer >= 0) mask |= 1 << gateLayer;
+        if (mask == 0) mask = Physics.DefaultRaycastLayers;
+
+        var halfExtents = new Vector3(blockSize.x * 0.45f, 1.5f, blockSize.z * 0.45f);
+        var hits = Physics.OverlapBox(pos + Vector3.up * 0.5f, halfExtents, Quaternion.identity, mask);
+        foreach (var hit in hits)
+        {
+            Destroy(hit.gameObject);
+        }
     }
 
     private Vector2 GetChunkEdgeStart(Chunk chunk, Vector3Int blockSize, Vector2Int tunnelDir)

--- a/Assets/Scripts/Manager/InGameLoop.cs
+++ b/Assets/Scripts/Manager/InGameLoop.cs
@@ -4,13 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Unity.Cinemachine;
-using Unity.VisualScripting;
-using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.SceneManagement;
-using static UnityEngine.Rendering.VirtualTexturing.Debugging;
 
 [System.Serializable]
 public class ObservableVariable<T>

--- a/Assets/Scripts/Manager/InGameLoop.cs
+++ b/Assets/Scripts/Manager/InGameLoop.cs
@@ -32,6 +32,7 @@ public class InGameLoop : ManagerBase<InGameLoop>
     public int ExitStage = 3;
     public int StageUpCount = 15;
     public float DeadDuration = 2f;
+    [Min(1f)] public float ManagerInitializationTimeout = 30f;
     public bool IsStartGame = false;
     public PlayerController Player;
     public UIController UI;
@@ -55,14 +56,23 @@ public class InGameLoop : ManagerBase<InGameLoop>
     private Vector3 m_lastPlayerPos;
     private async void Start()
     {
-        await Init();
+        try
+        {
+            await Init();
+        }
+        catch (Exception exception)
+        {
+            IsReady = false;
+            Debug.LogException(exception, this);
+        }
 
         StartCoroutine(GameStartRoutine());
     }
 
     private void OnDisable()
     {
-        KillCount.OnValueChanged -= OnUpdateKill;
+        if (KillCount != null)
+            KillCount.OnValueChanged -= OnUpdateKill;
     }
     private async Task Init()
     {
@@ -147,8 +157,22 @@ public class InGameLoop : ManagerBase<InGameLoop>
 
     IEnumerator GameStartRoutine()
     {
+        var startTime = Time.realtimeSinceStartup;
         while(m_managers != null && m_managers.Any(x => x.IsReady == false))
         {
+            if (Time.realtimeSinceStartup - startTime >= ManagerInitializationTimeout)
+            {
+                var pendingManagers = string.Join(
+                    ", ",
+                    m_managers.Where(manager => manager.IsReady == false)
+                        .Select(manager => manager.GetType().Name));
+                Debug.LogError(
+                    $"Game initialization timed out after {ManagerInitializationTimeout:F1}s. " +
+                    $"Pending managers: {pendingManagers}",
+                    this);
+                yield break;
+            }
+
             yield return null;
         }
         if (ChunkManager != null) StartCoroutine(ChunkManager.PlayerStartRoutine());

--- a/Assets/Scripts/Manager/InGameLoop.cs
+++ b/Assets/Scripts/Manager/InGameLoop.cs
@@ -54,6 +54,11 @@ public class InGameLoop : ManagerBase<InGameLoop>
     private InputActionMap m_originInputMap;
     private bool IsSpawnBoss;
     private Vector3 m_lastPlayerPos;
+    private AsyncOperationHandle<IList<GameObject>> m_npcHandle;
+    private AsyncOperationHandle<IList<InventoryItem>> m_itemHandle;
+    private AsyncOperationHandle<IList<GameObject>> m_enemyHandle;
+    private bool m_isDestroyed;
+
     private async void Start()
     {
         try
@@ -66,6 +71,7 @@ public class InGameLoop : ManagerBase<InGameLoop>
             Debug.LogException(exception, this);
         }
 
+        if (m_isDestroyed) return;
         StartCoroutine(GameStartRoutine());
     }
 
@@ -74,6 +80,19 @@ public class InGameLoop : ManagerBase<InGameLoop>
         if (KillCount != null)
             KillCount.OnValueChanged -= OnUpdateKill;
     }
+
+    private void OnDestroy()
+    {
+        m_isDestroyed = true;
+
+        if (m_npcHandle.IsValid())
+            Addressables.Release(m_npcHandle);
+        if (m_itemHandle.IsValid())
+            Addressables.Release(m_itemHandle);
+        if (m_enemyHandle.IsValid())
+            Addressables.Release(m_enemyHandle);
+    }
+
     private async Task Init()
     {
         IsSpawnBoss = false;
@@ -94,25 +113,25 @@ public class InGameLoop : ManagerBase<InGameLoop>
         // Spawner 초기화
         if (NPCSpawner != null)
         {
-            AsyncOperationHandle<IList<GameObject>> npcHandle =
-            Addressables.LoadAssetsAsync<GameObject>("NPC", null);
+            m_npcHandle = Addressables.LoadAssetsAsync<GameObject>("NPC", null);
 
-            AsyncOperationHandle<IList<InventoryItem>> itemHandle =
-            Addressables.LoadAssetsAsync<InventoryItem>("InventoryItem", null);
+            m_itemHandle = Addressables.LoadAssetsAsync<InventoryItem>("InventoryItem", null);
 
-            await itemHandle.Task;
-            await npcHandle.Task;
+            await m_itemHandle.Task;
+            if (m_isDestroyed) return;
+            await m_npcHandle.Task;
+            if (m_isDestroyed) return;
 
             var itemList = new List<InventoryItem>();
             var npcList = new List<NPCBase>();
             NPCSpawner.Items = itemList;
             NPCSpawner.AllNPCs = npcList;
 
-            if (itemHandle.Status == AsyncOperationStatus.Succeeded
-                && npcHandle.Status == AsyncOperationStatus.Succeeded)
+            if (m_itemHandle.Status == AsyncOperationStatus.Succeeded
+                && m_npcHandle.Status == AsyncOperationStatus.Succeeded)
             {
-                itemList.AddRange(itemHandle.Result);
-                foreach (var npc in npcHandle.Result)
+                itemList.AddRange(m_itemHandle.Result);
+                foreach (var npc in m_npcHandle.Result)
                 {
                     if (npc.TryGetComponent<NPCBase>(out var npcCtrl))
                         npcList.Add(npcCtrl);
@@ -129,17 +148,17 @@ public class InGameLoop : ManagerBase<InGameLoop>
 
         if (EnemySpawner != null)
         {
-            AsyncOperationHandle<IList<GameObject>> enemyHandle =
-            Addressables.LoadAssetsAsync<GameObject>("Enemy", null);
+            m_enemyHandle = Addressables.LoadAssetsAsync<GameObject>("Enemy", null);
 
-            await enemyHandle.Task;
+            await m_enemyHandle.Task;
+            if (m_isDestroyed) return;
 
             var enemyList = new List<EnemyController>();
             EnemySpawner.AllEnemys = enemyList;
 
-            if (enemyHandle.Status == AsyncOperationStatus.Succeeded)
+            if (m_enemyHandle.Status == AsyncOperationStatus.Succeeded)
             {
-                foreach (var enemy in enemyHandle.Result)
+                foreach (var enemy in m_enemyHandle.Result)
                 {
                     if (enemy.TryGetComponent<EnemyController>(out var enemyCtrl))
                         enemyList.Add(enemyCtrl);

--- a/Assets/Scripts/Manager/ScriptableObjectManager.cs
+++ b/Assets/Scripts/Manager/ScriptableObjectManager.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;

--- a/Assets/Scripts/Manager/ScriptableObjectManager.cs
+++ b/Assets/Scripts/Manager/ScriptableObjectManager.cs
@@ -8,22 +8,28 @@ public class ScriptableObjectManager : ManagerBase<ScriptableObjectManager>
     [SerializeField]
     private List<CSVScriptableObject> csvSO = new();
 
+    private AsyncOperationHandle<IList<CSVScriptableObject>> m_handle;
+    private bool m_isDestroyed;
+    private bool m_hasBackups;
+    private bool m_isReleased;
+
     private async void Start()
     {
-        AsyncOperationHandle<IList<CSVScriptableObject>> handle =
-            Addressables.LoadAssetsAsync<CSVScriptableObject>("SOManager", null);
+        m_handle = Addressables.LoadAssetsAsync<CSVScriptableObject>("SOManager", null);
 
-        await handle.Task;
+        await m_handle.Task;
+        if (m_isDestroyed) return;
 
-        if (handle.Status == AsyncOperationStatus.Succeeded)
+        if (m_handle.Status == AsyncOperationStatus.Succeeded)
         {
-            csvSO.AddRange(handle.Result);
+            csvSO.AddRange(m_handle.Result);
 
             foreach (var so in csvSO)
             {
                 so.Backup();
             }
 
+            m_hasBackups = true;
             IsReady = true;
         }
         else
@@ -34,9 +40,30 @@ public class ScriptableObjectManager : ManagerBase<ScriptableObjectManager>
 
     private void OnApplicationQuit()
     {
-        foreach (var item in csvSO)
+        RestoreAndRelease();
+    }
+
+    private void OnDestroy()
+    {
+        m_isDestroyed = true;
+        RestoreAndRelease();
+    }
+
+    private void RestoreAndRelease()
+    {
+        if (m_hasBackups)
         {
-            item.Restore();
+            foreach (var item in csvSO)
+            {
+                item.Restore();
+            }
+
+            m_hasBackups = false;
         }
+
+        if (m_isReleased || m_handle.IsValid() == false) return;
+
+        Addressables.Release(m_handle);
+        m_isReleased = true;
     }
 }

--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -78,7 +78,8 @@ public class NPCBase : MonoBehaviour
     private void Update()
     {
         if (m_isTouch == false) return;
-        if (m_player != null && m_player.input.actions["Interact"].triggered)
+        var interactAction = m_player?.input?.currentActionMap?.FindAction("Interact");
+        if (interactAction != null && interactAction.triggered)
         {
             // 플레이어 향해 회전
             var target = m_player.transform.position;
@@ -109,7 +110,7 @@ public class NPCBase : MonoBehaviour
             m_textLine = 0;
             // Dialog UI 제작후, 컨트롤러에 등록하면, 해당 Dialog UI를 활성화
 
-            m_dialog.gameObject.SetActive(true);
+            gameLoop.UI.ChangeState(UIState.Dialog);
             m_dialog.Init(this);
 
             m_isInteract = true;

--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -1,8 +1,4 @@
-using NUnit.Framework;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using Unity.AppUI.UI;
 using UnityEngine;
 using UnityEngine.AI;
 

--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -20,6 +20,7 @@ public class NPCBase : MonoBehaviour
     private ChunkManager m_chunkManager;
     private PlayerController m_player;
     private NPCDialog m_dialog;
+    private readonly HashSet<Collider> m_playerColliders = new();
 
     private void Awake()
     {
@@ -28,6 +29,8 @@ public class NPCBase : MonoBehaviour
     private void OnEnable()
     {
         m_isTouch = false;
+        m_player = null;
+        m_playerColliders.Clear();
         m_canSelectItem = true;
         m_isInteract = false;
         if (SelectItems != null && SelectItems.Count > 3)
@@ -55,25 +58,21 @@ public class NPCBase : MonoBehaviour
             gameLoop.StageLevel.OnValueChanged -= DestroyThisNPC;
         }
         if (NavAgent != null) NavAgent.enabled = false;
+        m_isTouch = false;
+        m_player = null;
+        m_playerColliders.Clear();
     }
 
     private void OnTriggerEnter(Collider other)
     {
-        m_isTouch = true;
-        if (m_isInteract)
-        {
-            Interact();
-            return;
-        }
+        if (other.CompareTag(TagManager.GetTagString(TargetTag.Player)) == false) return;
 
-        if (other.CompareTag(TagManager.GetTagString(TargetTag.Player)))
-        {
-            var ctrl = other.GetComponentInParent<PlayerController>();
-            if (ctrl != null)
-            {
-                m_player = ctrl;
-            }
-        }
+        var ctrl = other.GetComponentInParent<PlayerController>();
+        if (ctrl == null) return;
+
+        m_playerColliders.Add(other);
+        m_player = ctrl;
+        m_isTouch = true;
     }
 
     private void Update()
@@ -91,6 +90,9 @@ public class NPCBase : MonoBehaviour
     }
     private void OnTriggerExit(Collider other)
     {
+        if (m_playerColliders.Remove(other) == false) return;
+        if (m_playerColliders.Count > 0) return;
+
         m_isTouch = false;
         m_player = null;
     }

--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -32,7 +32,7 @@ public class NPCBase : MonoBehaviour
         m_isInteract = false;
         if (SelectItems != null && SelectItems.Count > 3)
         {
-            SelectItems.RemoveRange(3, DialogTexts.Count - 3);
+            SelectItems.RemoveRange(3, SelectItems.Count - 3);
         }
 
         if (InGameLoop.Instance != null)

--- a/Assets/Scripts/NPC/NPCDialog.cs
+++ b/Assets/Scripts/NPC/NPCDialog.cs
@@ -69,27 +69,39 @@ public class NPCDialog : UIElementBase
         if (selectItem != null)
         {
             var player = Controller.Player;
-            // ∞·¡¶
-            if (player != null
-                && player.model.Stats[StatType.Money].TotalValue < selectItem.Price)
+            if (player == null || player.model == null)
             {
-                mainTextMesh.text = "∫Ûº’¿∏∑Œ ∂« ø‘±∫. ¿Ãπ¯ø°µµ ∞≈∑°¥¬ æ¯æÓ.";
+                mainTextMesh.text = "Í±∞ÎûòÎ•º ÏßÑÌñâÌï† Ïàò ÏóÜÏäµÎãàÎã§.";
+            }
+            else if (player.model.Stats[StatType.Money].TotalValue < selectItem.Price)
+            {
+                mainTextMesh.text = "ÎπàÏÜêÏúºÎ°ú Îòê ÏôîÍµ∞. Ïù¥Î≤àÏóêÎèÑ Í±∞ÎûòÎäî ÏóÜÏñ¥.";
+            }
+            else if (Controller.UIElements.TryGetValue(UIState.Inventory, out var element) == false ||
+                     element is not InventorySystem inventory ||
+                     inventory.HasEmptySlot() == false)
+            {
+                mainTextMesh.text = "ÏÜåÏßÄÌíàÏù¥ Í∞ÄÎìù Ï∞ºÍµ∞. ÏûêÎ¶¨Î•º ÎπÑÏö∞Í≥† Îã§Ïãú Ïò§Í≤å.";
             }
             else
             {
-                player.model.Stats[StatType.Money].AddModifier(new StatModifier(-selectItem.Price), StatModifyType.BuyItem);
-
-                // æ∆¿Ã≈€ ª˝º∫«ÿº≠ ≥÷±‚
-                if (Controller.UIElements.TryGetValue(UIState.Inventory,out var element))
+                var purchasedItem = Instantiate(selectItem);
+                if (inventory.TryAddItem(purchasedItem))
                 {
-                    var inventory = element as InventorySystem;
-                    inventory?.TryAddItem(Instantiate(selectItem));
-                    mainTextMesh.text = "∞≈∑°¥¬ ≥°≥µº“. «‡øÓ¿ª ∫Ù¡ˆ, ∏«Ë∞°.";
+                    player.model.Stats[StatType.Money].AddModifier(
+                        new StatModifier(-selectItem.Price),
+                        StatModifyType.BuyItem);
+                    mainTextMesh.text = "Í±∞ÎûòÎäî ÎÅùÎÇ¨ÏÜå. ÌñâÏö¥ÏùÑ ÎπåÏßÄ, Î™®ÌóòÍ∞Ä.";
+                }
+                else
+                {
+                    Destroy(purchasedItem);
+                    mainTextMesh.text = "Í±∞ÎûòÎ•º ÏôÑÎ£åÌïòÏßÄ Î™ªÌñàÎÑ§. Îã§Ïãú ÏãúÎèÑÌï¥ Ï£ºÍ≤å.";
                 }
             }
         }
         Sequence seq = DOTween.Sequence();
-        seq.SetUpdate(true) // Time.timeScale π´Ω√
+        seq.SetUpdate(true) // Time.timeScale Î¨¥Ïãú
            .AppendInterval(2f)
            .OnComplete(() =>
            {

--- a/Assets/Scripts/NPC/NPCDialog.cs
+++ b/Assets/Scripts/NPC/NPCDialog.cs
@@ -21,7 +21,7 @@ public class NPCDialog : UIElementBase
 
     private void OnEnable()
     {
-        Controller.ChangeState(UIState.Dialog);
+        if (Controller == null) return;
 
         if (select != null && select.Count > 3)
         {
@@ -110,7 +110,7 @@ public class NPCDialog : UIElementBase
                {
                    item.btn.gameObject.SetActive(false);
                }
-               gameObject.SetActive(false);
+               Controller.ChangeState(UIState.None);
            });
     }
 }

--- a/Assets/Scripts/NPC/NPCSpawner.cs
+++ b/Assets/Scripts/NPC/NPCSpawner.cs
@@ -35,9 +35,10 @@ public class NPCSpawner : MonoBehaviour
         }
         foreach (var list in m_allItems.Values)
         {
-            list.OrderBy(item => item.Price);
+            list.Sort((left, right) => left.Price.CompareTo(right.Price));
         }
-        m_pickList = Enumerable.Range((int)ItemType.Helmet, (int)ItemType.Pants)
+        var itemTypeCount = (int)ItemType.Pants - (int)ItemType.Helmet + 1;
+        m_pickList = Enumerable.Range((int)ItemType.Helmet, itemTypeCount)
                             .Select(i => (ItemType)i)
                             .Where(t => m_allItems.ContainsKey(t)).ToList();
 
@@ -84,13 +85,17 @@ public class NPCSpawner : MonoBehaviour
         {
             if (m_allItems.TryGetValue((ItemType)pick,out var list))
             {
-                var segCount = list.Count / maxLevel;
-                var segRemind = list.Count % maxLevel;
+                if (list.Count == 0 || maxLevel <= 0) continue;
 
-                var startIdx = segCount * (curLevel - 1);
-                var endIdx = startIdx + segCount;
-                if (curLevel == 1) endIdx += segRemind;
-                var pickIdx = Random.Range(startIdx, endIdx + 1);
+                var clampedLevel = Mathf.Clamp(curLevel, 1, maxLevel);
+                var startIdx = Mathf.FloorToInt(
+                    (clampedLevel - 1) * list.Count / (float)maxLevel);
+                var endExclusive = Mathf.CeilToInt(
+                    clampedLevel * list.Count / (float)maxLevel);
+
+                startIdx = Mathf.Clamp(startIdx, 0, list.Count - 1);
+                endExclusive = Mathf.Clamp(endExclusive, startIdx + 1, list.Count);
+                var pickIdx = Random.Range(startIdx, endExclusive);
                 if (npc.SelectItems == null) npc.SelectItems = new();
 
                 npc.SelectItems.Add(list[pickIdx]);

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -131,13 +131,18 @@ public class PlayerCombat : MonoBehaviour
         var size = (int)InputSkill.Size;
         int bindingIndex = context.action.GetBindingIndexForControl(context.control);
         if (bindingIndex < 0 || bindingIndex >= size) return;
+        if (ctrl.machine.CanOtherAction() == false || bindingIndex >= skills.Count) return;
 
-        if (ctrl.machine.CanOtherAction() &&
-            bindingIndex < skills.Count &&
-            CanUseEquippedSkill(skills[bindingIndex]))
+        var skill = skills[bindingIndex];
+        if (IsEquippedSkillActive(skill) == false) return;
+
+        if (HasRequiredWeapon(skill) == false)
         {
-            StartCoroutine(skills[bindingIndex].Active(ctrl));
+            UIController.Instance?.ShowRequiredWeaponMessage(skill.RequireWeapon);
+            return;
         }
+
+        StartCoroutine(skill.Active(ctrl));
     }
     #endregion
 
@@ -187,14 +192,22 @@ public class PlayerCombat : MonoBehaviour
         return true;
     }
 
-    private bool CanUseEquippedSkill(SkillBase skill)
+    public bool CanUseEquippedSkill(SkillBase skill)
+    {
+        return IsEquippedSkillActive(skill) && HasRequiredWeapon(skill);
+    }
+
+    private bool IsEquippedSkillActive(SkillBase skill)
     {
         if (skill == null) return false;
 
         var state = GetSkillState(skill);
-        if (state == null || state.IsActive == false) return false;
+        return state != null && state.IsActive;
+    }
 
-        return skill.RequireWeapon == WeaponType.None ||
-               skill.RequireWeapon == CurType;
+    private bool HasRequiredWeapon(SkillBase skill)
+    {
+        return skill != null &&
+               (skill.RequireWeapon == WeaponType.None || skill.RequireWeapon == CurType);
     }
 }

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -15,6 +15,9 @@ public class PlayerCombat : MonoBehaviour
     private Dictionary<WeaponType, WeaponBase> weapons;
     private bool m_isInputSubscribed;
     private SkillRuntimeStateStore m_skillStates;
+    private InputAction m_skillAction;
+    private InputAction m_swapWeaponAction;
+    private InputAction m_attackAction;
 
     private readonly int lastWeaponParam = Animator.StringToHash("LastWeapon");
     private readonly int curWeaponParam = Animator.StringToHash("CurWeapon");
@@ -35,9 +38,14 @@ public class PlayerCombat : MonoBehaviour
         if (ctrl == null) ctrl = GetComponentInParent<PlayerController>();
         if (ctrl == null || ctrl.input == null || ctrl.input.actions == null) return;
 
-        ctrl.input.actions["Skill"].performed += OnSkill;
-        ctrl.input.actions["SwapWeapon"].performed += OnSwapWeapon;
-        ctrl.input.actions["Attack"].performed += OnAttack;
+        m_skillAction = ctrl.input.actions.FindAction("Player/Skill");
+        m_swapWeaponAction = ctrl.input.actions.FindAction("Player/SwapWeapon");
+        m_attackAction = ctrl.input.actions.FindAction("Player/Attack");
+        if (m_skillAction == null || m_swapWeaponAction == null || m_attackAction == null) return;
+
+        m_skillAction.performed += OnSkill;
+        m_swapWeaponAction.performed += OnSwapWeapon;
+        m_attackAction.performed += OnAttack;
         m_isInputSubscribed = true;
     }
 
@@ -50,9 +58,9 @@ public class PlayerCombat : MonoBehaviour
             return;
         }
 
-        ctrl.input.actions["Skill"].performed -= OnSkill;
-        ctrl.input.actions["SwapWeapon"].performed -= OnSwapWeapon;
-        ctrl.input.actions["Attack"].performed -= OnAttack;
+        m_skillAction.performed -= OnSkill;
+        m_swapWeaponAction.performed -= OnSwapWeapon;
+        m_attackAction.performed -= OnAttack;
         m_isInputSubscribed = false;
     }
 

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -126,7 +126,7 @@ public class PlayerCombat : MonoBehaviour
 
         if (ctrl.machine.CanOtherAction() &&
             bindingIndex < skills.Count &&
-            skills[bindingIndex] != null)
+            CanUseEquippedSkill(skills[bindingIndex]))
         {
             StartCoroutine(skills[bindingIndex].Active(ctrl));
         }
@@ -177,5 +177,16 @@ public class PlayerCombat : MonoBehaviour
         }
 
         return true;
+    }
+
+    private bool CanUseEquippedSkill(SkillBase skill)
+    {
+        if (skill == null) return false;
+
+        var state = GetSkillState(skill);
+        if (state == null || state.IsActive == false) return false;
+
+        return skill.RequireWeapon == WeaponType.None ||
+               skill.RequireWeapon == CurType;
     }
 }

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -14,6 +14,7 @@ public class PlayerCombat : MonoBehaviour
     private WeaponBase curWeapon;
     private Dictionary<WeaponType, WeaponBase> weapons;
     private bool m_isInputSubscribed;
+    private SkillRuntimeStateStore m_skillStates;
 
     private readonly int lastWeaponParam = Animator.StringToHash("LastWeapon");
     private readonly int curWeaponParam = Animator.StringToHash("CurWeapon");
@@ -123,7 +124,9 @@ public class PlayerCombat : MonoBehaviour
         int bindingIndex = context.action.GetBindingIndexForControl(context.control);
         if (bindingIndex < 0 || bindingIndex >= size) return;
 
-        if (ctrl.machine.CanOtherAction() && skills[bindingIndex] != null)
+        if (ctrl.machine.CanOtherAction() &&
+            bindingIndex < skills.Count &&
+            skills[bindingIndex] != null)
         {
             StartCoroutine(skills[bindingIndex].Active(ctrl));
         }
@@ -132,6 +135,7 @@ public class PlayerCombat : MonoBehaviour
 
     private void Awake()
     {
+        m_skillStates = SkillRuntimeStateStore.GetOrCreate(this);
         weapons = new()
         {
             {WeaponType.None, null},
@@ -147,5 +151,29 @@ public class PlayerCombat : MonoBehaviour
     public WeaponBase GetCurWeapon()
     {
         return curWeapon;
+    }
+
+    public SkillRuntimeState GetSkillState(SkillBase skill)
+    {
+        m_skillStates ??= SkillRuntimeStateStore.GetOrCreate(this);
+        return m_skillStates?.GetState(skill);
+    }
+
+    public bool IsSkillUnlocked(SkillBase skill)
+    {
+        if (skill == null) return false;
+        if (skill.CanUnlock) return true;
+        if (skill.RequireSkill == null || skill.RequireSkill.Length == 0) return false;
+
+        foreach (var requiredSkill in skill.RequireSkill)
+        {
+            var requiredState = GetSkillState(requiredSkill);
+            if (requiredSkill == null || requiredState == null || requiredState.IsActive == false)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Assets/Scripts/Player/PlayerCombat.cs
+++ b/Assets/Scripts/Player/PlayerCombat.cs
@@ -142,10 +142,12 @@ public class PlayerCombat : MonoBehaviour
         };
         CurType = WeaponType.None;
 
-        skills = new()
+        skills ??= new List<SkillBase>();
+        var requiredSkillSlots = (int)InputSkill.Size;
+        while (skills.Count < requiredSkillSlots)
         {
-            null, null, null,
-        };
+            skills.Add(null);
+        }
     }
 
     public WeaponBase GetCurWeapon()

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -17,11 +17,54 @@ public class PlayerController : MonoBehaviour
     public CinemachineImpulseSource Impulse;
     public Volume hitScreenVolume;
 
+    private Vector3 m_desiredPlanarVelocity;
+    private Quaternion m_desiredRotation;
+    private bool m_hasDesiredRotation;
+    private Vector3 m_pendingRootMotion;
+
     private void LateUpdate()
     {
-        var pos = body.localPosition;
-        transform.position += transform.TransformDirection(pos);
+        if (body == null) return;
+
+        m_pendingRootMotion += transform.TransformDirection(body.localPosition);
         body.localPosition = Vector3.zero;
+    }
+
+    private void FixedUpdate()
+    {
+        if (Rigid == null) return;
+
+        if (Rigid.isKinematic == false)
+        {
+            var velocity = Rigid.linearVelocity;
+            Rigid.linearVelocity = new Vector3(
+                m_desiredPlanarVelocity.x,
+                velocity.y,
+                m_desiredPlanarVelocity.z);
+        }
+
+        if (m_hasDesiredRotation)
+        {
+            Rigid.MoveRotation(m_desiredRotation);
+        }
+
+        if (m_pendingRootMotion.sqrMagnitude > Mathf.Epsilon)
+        {
+            Rigid.MovePosition(Rigid.position + m_pendingRootMotion);
+            m_pendingRootMotion = Vector3.zero;
+        }
+    }
+
+    public void SetMovement(Vector3 planarVelocity, Quaternion rotation)
+    {
+        m_desiredPlanarVelocity = planarVelocity;
+        m_desiredRotation = rotation;
+        m_hasDesiredRotation = true;
+    }
+
+    public void StopMovement()
+    {
+        m_desiredPlanarVelocity = Vector3.zero;
     }
 
     public void SetActionMap(InputActionMap mode)

--- a/Assets/Scripts/Player/PoolSystem/ObjectPool.cs
+++ b/Assets/Scripts/Player/PoolSystem/ObjectPool.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 [System.Serializable]
@@ -12,12 +11,12 @@ public class ObjectPool<T> where T : Component
     private Queue<T> pool;
     private Transform m_inactiveRoot;
 
-    public void Init(Transform parent = null)
+    public void Init(Transform parent = null, int initialSize = -1)
     {
         pool = new Queue<T>();
         if (this.parent == null) this.parent = parent;
         EnsureInactiveRoot();
-        CreateObject(InitSize);
+        CreateObject(initialSize < 0 ? InitSize : initialSize);
     }
 
     private void CreateObject(int size)
@@ -28,7 +27,6 @@ public class ObjectPool<T> where T : Component
         {
             var obj = GameObject.Instantiate(poolObj, m_inactiveRoot);
             obj.gameObject.SetActive(false);
-            obj.transform.SetParent(parent, false);
             pool.Enqueue(obj);
         }
     }
@@ -55,6 +53,7 @@ public class ObjectPool<T> where T : Component
         }
 
         var obj = pool.Dequeue();
+        obj.transform.SetParent(parent, false);
         if (activate)
             obj.gameObject.SetActive(true);
         return obj;
@@ -65,6 +64,7 @@ public class ObjectPool<T> where T : Component
         if (pool == null) pool = new Queue<T>();
 
         obj.gameObject.SetActive(false);
+        obj.transform.SetParent(m_inactiveRoot, false);
         pool.Enqueue(obj);
     }
 
@@ -85,6 +85,17 @@ public class ObjectPool<T> where T : Component
             {
                 CreateObject(1);
             }
+            yield return null;
+        }
+    }
+
+    public IEnumerator Warmup(int maxCreatePerFrame)
+    {
+        maxCreatePerFrame = Mathf.Max(1, maxCreatePerFrame);
+
+        while (Count() < InitSize)
+        {
+            CreateObject(Mathf.Min(maxCreatePerFrame, InitSize - Count()));
             yield return null;
         }
     }

--- a/Assets/Scripts/Player/PoolSystem/ObjectPool.cs
+++ b/Assets/Scripts/Player/PoolSystem/ObjectPool.cs
@@ -45,7 +45,7 @@ public class ObjectPool<T> where T : Component
             m_inactiveRoot.SetParent(parent, false);
     }
 
-    public T GetObject()
+    public T GetObject(bool activate = true)
     {
         if (pool == null) pool = new Queue<T>();
 
@@ -55,7 +55,8 @@ public class ObjectPool<T> where T : Component
         }
 
         var obj = pool.Dequeue();
-        obj.gameObject.SetActive(true);
+        if (activate)
+            obj.gameObject.SetActive(true);
         return obj;
     }
 

--- a/Assets/Scripts/Player/PoolSystem/ObjectPool.cs
+++ b/Assets/Scripts/Player/PoolSystem/ObjectPool.cs
@@ -10,22 +10,39 @@ public class ObjectPool<T> where T : Component
     public Transform parent;
     public int InitSize;
     private Queue<T> pool;
+    private Transform m_inactiveRoot;
 
     public void Init(Transform parent = null)
     {
         pool = new Queue<T>();
         if (this.parent == null) this.parent = parent;
+        EnsureInactiveRoot();
         CreateObject(InitSize);
     }
 
     private void CreateObject(int size)
     {
+        EnsureInactiveRoot();
+
         for (int i = 0; i < size; i++)
         {
-            var obj = GameObject.Instantiate(poolObj, parent);
+            var obj = GameObject.Instantiate(poolObj, m_inactiveRoot);
             obj.gameObject.SetActive(false);
+            obj.transform.SetParent(parent, false);
             pool.Enqueue(obj);
         }
+    }
+
+    private void EnsureInactiveRoot()
+    {
+        if (m_inactiveRoot != null) return;
+
+        var root = new GameObject($"{typeof(T).Name} Pool Inactive Root");
+        root.SetActive(false);
+        m_inactiveRoot = root.transform;
+
+        if (parent != null)
+            m_inactiveRoot.SetParent(parent, false);
     }
 
     public T GetObject()

--- a/Assets/Scripts/Player/Skill/AreaSkill.cs
+++ b/Assets/Scripts/Player/Skill/AreaSkill.cs
@@ -1,10 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Unity.VisualScripting.Antlr3.Runtime.Misc;
-using Unity.VisualScripting.FullSerializer;
 using UnityEngine;
-using static UnityEngine.UI.Image;
 
 [CreateAssetMenu(fileName = "AreaSkill", menuName = "Scriptable Objects/Area Skill")]
 public class AreaSkill: SkillBase

--- a/Assets/Scripts/Player/Skill/AreaSkill.cs
+++ b/Assets/Scripts/Player/Skill/AreaSkill.cs
@@ -59,6 +59,8 @@ public class AreaSkill: SkillBase
         if (stats.TryGetValue(StatType.AttackPower, out var stat))
             atk = stat.TotalValue;
 
+        var damagedPlayers = new HashSet<PlayerModel>();
+        var damagedEnemies = new HashSet<EnemyStat>();
         foreach (Collider hit in hits)
         {
             if (hit.CompareTag(TagManager.GetTagString(target)))
@@ -72,11 +74,19 @@ public class AreaSkill: SkillBase
                 }
                 if (target == TargetTag.Player)
                 {
-                    hit.GetComponentInParent<PlayerModel>().ApplyDamage(Damage + atk, origin.transform.position, KnockBackForce);
+                    var player = hit.GetComponentInParent<PlayerModel>();
+                    if (player != null && damagedPlayers.Add(player))
+                    {
+                        player.ApplyDamage(Damage + atk, origin.transform.position, KnockBackForce);
+                    }
                 }
                 else if (target == TargetTag.Enemy)
                 {
-                    hit.GetComponentInParent<EnemyStat>().ApplyDamage(Damage + atk, origin.transform.position, KnockBackForce);
+                    var enemy = hit.GetComponentInParent<EnemyStat>();
+                    if (enemy != null && damagedEnemies.Add(enemy))
+                    {
+                        enemy.ApplyDamage(Damage + atk, origin.transform.position, KnockBackForce);
+                    }
                 }
             }
         }

--- a/Assets/Scripts/Player/Skill/AreaSkill.cs
+++ b/Assets/Scripts/Player/Skill/AreaSkill.cs
@@ -16,34 +16,42 @@ public class AreaSkill: SkillBase
 
     public override IEnumerator Active(PlayerController player)
     {
-        if (player.combat.CurType != RequireWeapon)
-        {
-            isFailSkill = true;
-            yield break;
-        }
+        if (player == null || player.combat.CurType != RequireWeapon) yield break;
+        if (player.model.Stats.TryGetValue(StatType.Mana, out var mp) == false) yield break;
 
-        yield return base.Active(player);
+        var context = CreateContext(player.combat, player.transform);
+        yield return BeginSkill(player.combat, player.transform, mp, context, player);
 
-        if (isFailSkill) yield break;
-        Hit(player.transform, player.model.Stats, TargetTag.Enemy);
+        if (context.Failed) yield break;
+        Hit(player.transform, player.model.Stats, TargetTag.Enemy, context);
         yield break;
     }
 
     public override IEnumerator Active(Transform origin, Dictionary<StatType, Stat> stats, GameObject Target)
     {
-        yield return base.Active(origin, stats, Target);
+        if (origin == null || stats == null || stats.TryGetValue(StatType.Mana, out var mp) == false) yield break;
 
-        if (isFailSkill) yield break;
-        Hit(origin, stats,TagManager.TryGetTargetTag(Target.tag));
+        var owner = origin.GetComponentInParent<EnemyController>() as Component ?? origin;
+        var context = CreateContext(owner, origin);
+        yield return BeginSkill(owner, origin, mp, context);
 
+        if (context.Failed || Target == null) yield break;
+        Hit(origin, stats, TagManager.TryGetTargetTag(Target.tag), context);
         yield break;
     }
 
-    public void Hit(Transform origin, Dictionary<StatType, Stat> stats, TargetTag Target)
+    public void Hit(
+        Transform origin,
+        Dictionary<StatType, Stat> stats,
+        TargetTag target,
+        SkillExecutionContext context)
     {
-        SetStartPos(origin);
-        var center = this.center + foward * HitOffset.z + right * HitOffset.x + up * HitOffset.y;
-        var rotation = Quaternion.LookRotation(foward);
+        UpdateStartPose(origin, context);
+        var center = context.Center
+                     + context.Forward * HitOffset.z
+                     + context.Right * HitOffset.x
+                     + context.Up * HitOffset.y;
+        var rotation = Quaternion.LookRotation(context.Forward);
         Vector3 halfExtents = Range * 0.5f;
 
         Collider[] hits = Physics.OverlapBox(center, halfExtents, rotation, TargetLayer);
@@ -56,20 +64,20 @@ public class AreaSkill: SkillBase
 
         foreach (Collider hit in hits)
         {
-            if (hit.CompareTag(TagManager.GetTagString(Target)))
+            if (hit.CompareTag(TagManager.GetTagString(target)))
             {
                 var Damage = 0f;
                 var atts = SkillStats.Where(skillStat => skillStat.StatType == StatType.AttackPower).ToArray();
                 if (atts.Length > 0)
                 {
                     var baseDamage = atts[0].StatModifier.FixedValue * (atts[0].StatModifier.PercentValue + 1);
-                    Damage = atts[0].EnforceStatFactor * EnforceLevel + baseDamage;
+                    Damage = atts[0].EnforceStatFactor * context.State.EnforceLevel + baseDamage;
                 }
-                if (Target == TargetTag.Player)
+                if (target == TargetTag.Player)
                 {
                     hit.GetComponentInParent<PlayerModel>().ApplyDamage(Damage + atk, origin.transform.position, KnockBackForce);
                 }
-                else if (Target == TargetTag.Enemy)
+                else if (target == TargetTag.Enemy)
                 {
                     hit.GetComponentInParent<EnemyStat>().ApplyDamage(Damage + atk, origin.transform.position, KnockBackForce);
                 }

--- a/Assets/Scripts/Player/Skill/ProjectileSkill.cs
+++ b/Assets/Scripts/Player/Skill/ProjectileSkill.cs
@@ -16,30 +16,34 @@ public class ProjectileSkill : SkillBase
 
     public override IEnumerator Active(Transform origin, Dictionary<StatType, Stat> stats, GameObject Target)
     {
-        if (ProjectileManager.Instance == null || ProjectileType == ProjectileType.None) yield break;
-        yield return base.Active(origin, stats, Target);
+        if (ProjectileManager.Instance == null || ProjectileType == ProjectileType.None ||
+            origin == null || stats == null || stats.TryGetValue(StatType.Mana, out var mp) == false) yield break;
 
-        if (isFailSkill == false && stats.TryGetValue(StatType.AttackPower, out var atk) == true)
+        var owner = origin.GetComponentInParent<EnemyController>() as Component ?? origin;
+        var context = CreateContext(owner, origin);
+        yield return BeginSkill(owner, origin, mp, context);
+
+        if (context.Failed == false && stats.TryGetValue(StatType.AttackPower, out var atk))
         {
             if (Target == null) yield break;
 
             origin.LookAt(Target.transform);
-            SetStartPos(origin);
+            UpdateStartPose(origin, context);
 
             var pool = ProjectileManager.Instance.ProjectileDic[ProjectileType];
             var bullet = pool.GetObject();
             var trans = bullet.transform;
-            trans.position = center;
+            trans.position = context.Center;
             trans.rotation = origin.rotation;
 
-            var velocity = foward * Speed;
+            var velocity = context.Forward * Speed;
 
             var Damage = 0f;
             var atts = SkillStats.Where(skillStat => skillStat.StatType == StatType.AttackPower).ToArray();
             if (atts.Length > 0)
             {
                 var baseDamage = atts[0].StatModifier.FixedValue * (atts[0].StatModifier.PercentValue + 1);
-                Damage = atts[0].EnforceStatFactor * EnforceLevel + baseDamage;
+                Damage = atts[0].EnforceStatFactor * context.State.EnforceLevel + baseDamage;
             }
 
             bullet.Init(Damage + atk.TotalValue, LifeTime, velocity, KnockBackForce, TagManager.TryGetTargetTag(Target.tag), pool);

--- a/Assets/Scripts/Player/Skill/SkillBase.cs
+++ b/Assets/Scripts/Player/Skill/SkillBase.cs
@@ -1,11 +1,54 @@
 using System.Collections;
 using System.Collections.Generic;
-using Unity.VisualScripting;
-using Unity.VisualScripting.Antlr3.Runtime.Misc;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.Rendering;
-using UnityEngine.Serialization;
+
+public sealed class SkillRuntimeState
+{
+    public bool IsActive;
+    public int EnforceLevel;
+    public float LastUseTime;
+
+    public SkillRuntimeState(SkillBase skill)
+    {
+        IsActive = skill.CanActive;
+        EnforceLevel = skill.EnforceLevel;
+        LastUseTime = -skill.Cooldown;
+    }
+}
+
+public sealed class SkillRuntimeStateStore : MonoBehaviour
+{
+    private readonly Dictionary<SkillBase, SkillRuntimeState> m_states = new();
+
+    public SkillRuntimeState GetState(SkillBase skill)
+    {
+        if (skill == null) return null;
+        if (m_states.TryGetValue(skill, out var state) == false)
+        {
+            state = new SkillRuntimeState(skill);
+            m_states.Add(skill, state);
+        }
+        return state;
+    }
+
+    public static SkillRuntimeStateStore GetOrCreate(Component owner)
+    {
+        if (owner == null) return null;
+        var store = owner.GetComponent<SkillRuntimeStateStore>();
+        return store != null ? store : owner.gameObject.AddComponent<SkillRuntimeStateStore>();
+    }
+}
+
+public sealed class SkillExecutionContext
+{
+    public SkillRuntimeState State;
+    public Vector3 Center;
+    public Vector3 Forward;
+    public Vector3 Right;
+    public Vector3 Up;
+    public bool Failed;
+}
 
 [CreateAssetMenu(fileName = "SkillBase", menuName = "Scriptable Objects/Skill Base")]
 public abstract class SkillBase : CSVScriptableObject
@@ -45,72 +88,76 @@ public abstract class SkillBase : CSVScriptableObject
     public float ActiveDelay = 1f;
     public float EffectDelay = 0.5f;
 
-    private HashSet<SkillBase> m_lockRequireSkills;
-    private float m_lastSkillUseTime;
-    protected Vector3 center;
-    protected Vector3 foward;
-    protected Vector3 right;
-    protected Vector3 up;
-
-    protected bool isFailSkill;
-
-
-    public virtual void OnEnable()
+    public float GetEnforceCost(SkillRuntimeState state)
     {
-        m_lastSkillUseTime = -Cooldown;
-        m_lockRequireSkills = new HashSet<SkillBase>();
-        foreach (SkillBase skill in RequireSkill)
-        {
-            m_lockRequireSkills.Add(skill);
-        }
-    }
-    public void UnlockRequireSkill(SkillBase skill)
-    {
-        if (m_lockRequireSkills.Contains(skill))
-        {
-            m_lockRequireSkills.Remove(skill);
-        }
-        if (m_lockRequireSkills.Count < 1) CanUnlock = true;
+        var level = state?.EnforceLevel ?? EnforceLevel;
+        return EnforceBaseCost * (1 + level * EnforceCostFactor);
     }
 
-    public bool CanUseSkill(Stat mp, bool currentUse = true)
+    public bool CanUseSkill(Component owner, Stat mp, bool currentUse = true)
     {
-        if (currentUse) isFailSkill = false;
-        if (mp ==  null) mp = new Stat();
+        var state = SkillRuntimeStateStore.GetOrCreate(owner)?.GetState(this);
+        if (state == null) return false;
 
-        if (Time.time - m_lastSkillUseTime < Cooldown
+        if (mp == null) mp = new Stat();
+
+        if (Time.time - state.LastUseTime < Cooldown
             || CostMP > mp.TotalValue)
         {
-            if (currentUse) isFailSkill = true;
             return false;
         }
 
         if (currentUse)
         {
             mp.AddModifier(new StatModifier(-CostMP, 0), StatModifyType.SkillUse);
-            m_lastSkillUseTime = Time.time;
+            state.LastUseTime = Time.time;
         }
 
         return true;
     }
 
-    protected void SetStartPos(Transform origin)
+    protected SkillExecutionContext CreateContext(Component owner, Transform origin)
     {
-        foward = origin.forward;
-        right = origin.right;
-        up = origin.up;
-        center = origin.position + foward * StartOffset.z + right * StartOffset.x + up * StartOffset.y;
+        var state = SkillRuntimeStateStore.GetOrCreate(owner)?.GetState(this);
+        var context = new SkillExecutionContext
+        {
+            State = state
+        };
+        UpdateStartPose(origin, context);
+        return context;
+    }
+
+    protected void UpdateStartPose(Transform origin, SkillExecutionContext context)
+    {
+        context.Forward = origin.forward;
+        context.Right = origin.right;
+        context.Up = origin.up;
+        context.Center = origin.position
+                         + context.Forward * StartOffset.z
+                         + context.Right * StartOffset.x
+                         + context.Up * StartOffset.y;
         var navAgent = origin.GetComponentInParent<NavMeshAgent>();
         if (navAgent != null)
         {
             navAgent.updateRotation = false;
-            origin.LookAt(center);
+            origin.LookAt(context.Center);
             navAgent.updateRotation = true;
         }
     }
 
-    private IEnumerator SkillEffect(Transform origin, PlayerController player = null)
+    protected IEnumerator BeginSkill(
+        Component owner,
+        Transform origin,
+        Stat mp,
+        SkillExecutionContext context,
+        PlayerController player = null)
     {
+        if (CanUseSkill(owner, mp) == false)
+        {
+            context.Failed = true;
+            yield break;
+        }
+
         if (SkillType != VFX.None)
         {
             if (player != null)
@@ -119,29 +166,27 @@ public abstract class SkillBase : CSVScriptableObject
                 player.machine.ChangeState(StateType.Skill);
             }
             yield return new WaitForSeconds(EffectDelay);
-            SetStartPos(origin.transform);
-            SkillEffectManager.Instance.PlayVFX(SkillType, center, origin.rotation);
+            UpdateStartPose(origin, context);
+            SkillEffectManager.Instance?.PlayVFX(SkillType, context.Center, origin.rotation);
         }
+
+        yield return new WaitForSeconds(ActiveDelay);
     }
 
     public virtual IEnumerator Active(PlayerController player)
     {
-        if (player != null && player.model.Stats.TryGetValue(StatType.Mana, out var mp))
-        {
-            if (CanUseSkill(mp) == false) yield break;
-            yield return SkillEffect(player.transform,player);
-        }
-        yield return new WaitForSeconds(ActiveDelay);
+        if (player == null || player.model.Stats.TryGetValue(StatType.Mana, out var mp) == false) yield break;
+
+        var context = CreateContext(player.combat, player.transform);
+        yield return BeginSkill(player.combat, player.transform, mp, context, player);
     }
 
     public virtual IEnumerator Active(Transform origin, Dictionary<StatType,Stat> stats, GameObject Target)
     {
-        if (origin != null && stats.TryGetValue(StatType.Mana,out var mp))
-        {
-            if (CanUseSkill(mp) == false) yield break;
-            yield return SkillEffect(origin);
-        }
+        if (origin == null || stats == null || stats.TryGetValue(StatType.Mana, out var mp) == false) yield break;
 
-        yield return new WaitForSeconds(ActiveDelay);
+        var owner = origin.GetComponentInParent<EnemyController>() as Component ?? origin;
+        var context = CreateContext(owner, origin);
+        yield return BeginSkill(owner, origin, mp, context);
     }
 }

--- a/Assets/Scripts/Player/Skill/SkillBase.cs
+++ b/Assets/Scripts/Player/Skill/SkillBase.cs
@@ -165,12 +165,34 @@ public abstract class SkillBase : CSVScriptableObject
                 player.animator.SetInteger(skillAnimationParam, (int)SkillType);
                 player.machine.ChangeState(StateType.Skill);
             }
-            yield return new WaitForSeconds(EffectDelay);
-            UpdateStartPose(origin, context);
-            SkillEffectManager.Instance?.PlayVFX(SkillType, context.Center, origin.rotation);
+
+            var effectDelay = Mathf.Max(0f, EffectDelay);
+            if (effectDelay <= 0f)
+            {
+                PlaySkillEffect(origin);
+            }
+            else if (owner is MonoBehaviour coroutineOwner)
+            {
+                coroutineOwner.StartCoroutine(PlaySkillEffectAfterDelay(origin, effectDelay));
+            }
         }
 
-        yield return new WaitForSeconds(ActiveDelay);
+        yield return new WaitForSeconds(Mathf.Max(0f, ActiveDelay));
+    }
+
+    private IEnumerator PlaySkillEffectAfterDelay(Transform origin, float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        PlaySkillEffect(origin);
+    }
+
+    private void PlaySkillEffect(Transform origin)
+    {
+        if (origin == null) return;
+
+        var effectContext = new SkillExecutionContext();
+        UpdateStartPose(origin, effectContext);
+        SkillEffectManager.Instance?.PlayVFX(SkillType, effectContext.Center, origin.rotation);
     }
 
     public virtual IEnumerator Active(PlayerController player)

--- a/Assets/Scripts/Player/Skill/StatSkill.cs
+++ b/Assets/Scripts/Player/Skill/StatSkill.cs
@@ -1,51 +1,61 @@
-using NUnit.Framework;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "StatSkill", menuName = "Scriptable Objects/Stat Skill")]
-public class StatSkill: SkillBase
+public class StatSkill : SkillBase
 {
     public override IEnumerator Active(PlayerController player)
     {
-        // 요구 조건 만족 후, 스킬 사용
-        foreach (StatChange statChange in SkillStats)
+        if (player == null ||
+            player.model.Stats.TryGetValue(StatType.Mana, out var mp) == false)
         {
-            if (player.model.Stats[statChange.StatType].TotalValue < statChange.MinNeeded)
-                yield break;
+            yield break;
         }
 
-        yield return base.Active(player);
+        // Validate requirements before consuming mana or cooldown.
+        foreach (var statChange in SkillStats)
+        {
+            if (player.model.Stats.TryGetValue(statChange.StatType, out var stat) == false ||
+                stat.TotalValue < statChange.MinNeeded)
+            {
+                yield break;
+            }
+        }
 
-        if (isFailSkill) yield break;
+        var context = CreateContext(player.combat, player.transform);
+        yield return BeginSkill(player.combat, player.transform, mp, context, player);
+
+        if (context.Failed) yield break;
 
         var maxDuration = 0f;
-        // 스탯 관련 로직 적용
-        foreach (StatChange statChange in SkillStats)
+        foreach (var statChange in SkillStats)
         {
             maxDuration = Mathf.Max(maxDuration, statChange.Duration);
-            player.StartCoroutine(ApplyStatChange(player, statChange));
+            player.StartCoroutine(
+                ApplyStatChange(player, statChange, context.State.EnforceLevel));
         }
+
         yield return new WaitForSeconds(maxDuration);
     }
 
-    private IEnumerator ApplyStatChange(PlayerController player, StatChange statChange)
+    private IEnumerator ApplyStatChange(
+        PlayerController player,
+        StatChange statChange,
+        int enforceLevel)
     {
-        StatType type = statChange.StatType;
+        var factor = Mathf.Max(0f, statChange.EnforceStatFactor);
+        var modifier = statChange.StatModifier * (factor + 1) * enforceLevel;
+        var stat = player.model.Stats[statChange.StatType];
 
-        // 강화 레벨 * (스탯 증폭치 + 1) * 원래 수치
-        var factor = statChange.EnforceStatFactor < 0f ? 0f: statChange.EnforceStatFactor;
-        var stat = statChange.StatModifier * (factor + 1) * EnforceLevel;
-
-        // 일시적 버프
         if (statChange.Duration > 0f)
         {
-            player.model.Stats[type].AddModifier(stat, StatModifyType.Buff);
+            stat.AddModifier(modifier, StatModifyType.Buff);
             yield return new WaitForSeconds(statChange.Duration);
-            player.model.Stats[type].AddModifier(-stat, StatModifyType.Buff);
+            stat.AddModifier(-modifier, StatModifyType.Buff);
         }
-        // 영구 버프
-        else player.model.Stats[type].AddModifier(stat, StatModifyType.Permanent);
+        else
+        {
+            stat.AddModifier(modifier, StatModifyType.Permanent);
+        }
     }
 }

--- a/Assets/Scripts/Player/States/WalkState.cs
+++ b/Assets/Scripts/Player/States/WalkState.cs
@@ -31,7 +31,6 @@ public class WalkState : State
         }
         var camDir = new Vector3(m_cam.forward.x, 0, m_cam.forward.z);
         var dir = Quaternion.LookRotation(camDir) * move;
-        ctrl.transform.rotation = Quaternion.LookRotation(dir);
 
         float runInput = ctrl.input.actions[runAction].ReadValue<float>();
         var isRun = runInput > 0.1f;
@@ -40,7 +39,7 @@ public class WalkState : State
         anim.SetBool(runParam, isRun);
         anim.SetBool(walkParam, !isRun);
 
-        ctrl.Rigid.linearVelocity = new Vector3(dir.x * spd, ctrl.Rigid.linearVelocity.y, dir.z * spd);
+        ctrl.SetMovement(dir * spd, Quaternion.LookRotation(dir));
     }
 
     public override void Exit() 
@@ -48,6 +47,6 @@ public class WalkState : State
         base.Exit();
         anim.SetBool(walkParam, false);
         anim.SetBool(runParam, false);
-        ctrl.Rigid.linearVelocity = new Vector3(0, ctrl.Rigid.linearVelocity.y, 0);
+        ctrl.StopMovement();
     }
 }

--- a/Assets/Scripts/Player/Weapons/WeaponBase.cs
+++ b/Assets/Scripts/Player/Weapons/WeaponBase.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class WeaponBase: MonoBehaviour
@@ -96,7 +97,7 @@ public class WeaponBase: MonoBehaviour
 
         Tool.DrawOverlapBox(center, range, rotation, Color.green, 2f);
 
-        EnemyStat stat = null;
+        var damagedTargets = new HashSet<EnemyStat>();
         m_lastHitSucceeded = false;
         m_lastHitPosition = Vector3.zero;
         var additionalDamage = action.AdditionalDamage;
@@ -105,8 +106,8 @@ public class WeaponBase: MonoBehaviour
         {
             if (hit.CompareTag(TagManager.GetTagString(TargetTag.Enemy)))
             {
-                stat = hit.GetComponentInParent<EnemyStat>();
-                if (stat != null)
+                var stat = hit.GetComponentInParent<EnemyStat>();
+                if (stat != null && damagedTargets.Add(stat))
                 {
                     stat.ApplyDamage(ctrl.model.AttackPower.TotalValue + additionalDamage, ctrl.transform.position , knockBackForce);
                     m_lastHitSucceeded = true;

--- a/Assets/Scripts/Player/Weapons/WeaponBase.cs
+++ b/Assets/Scripts/Player/Weapons/WeaponBase.cs
@@ -18,6 +18,7 @@ public class WeaponBase: MonoBehaviour
     private Coroutine m_hitRoutine;
     private bool m_lastHitSucceeded;
     private Vector3 m_lastHitPosition;
+    private int m_attackSequence;
 
     public virtual void AddWeapon(WeaponType type)
     {
@@ -43,32 +44,34 @@ public class WeaponBase: MonoBehaviour
         m_hasPendingHit = true;
         m_pendingAttackIndex = m_attackCount;
         m_pendingAction = GetAttackAction(m_attackCount);
+        m_attackSequence++;
 
         if (ShouldUseAnimationEventHit() == false)
         {
             if (m_hitRoutine != null)
                 StopCoroutine(m_hitRoutine);
 
-            m_hitRoutine = StartCoroutine(HitRoutine(m_pendingAction));
+            m_hitRoutine = StartCoroutine(HitRoutine(m_pendingAction, m_attackSequence));
         }
 
         m_lastAttackTime = Time.time;
 
     }
 
-    IEnumerator HitRoutine(WeaponAttackSO action)
+    IEnumerator HitRoutine(WeaponAttackSO action, int attackSequence)
     {
         var delay = GetFallbackHitDelay(action);
         if (delay > 0f)
             yield return new WaitForSeconds(delay);
 
-        ApplyHit(action);
+        if (IsCurrentAttack(action, attackSequence))
+            ApplyHit(action);
         m_hitRoutine = null;
     }
 
-    public void ApplyAnimationEventHit()
+    public bool ApplyAnimationEventHit(WeaponAttackSO action, int attackSequence)
     {
-        if (m_hasPendingHit == false) return;
+        if (IsCurrentAttack(action, attackSequence) == false) return false;
 
         if (m_hitRoutine != null)
         {
@@ -76,7 +79,8 @@ public class WeaponBase: MonoBehaviour
             m_hitRoutine = null;
         }
 
-        ApplyHit(m_pendingAction);
+        ApplyHit(action);
+        return m_lastHitSucceeded;
     }
 
     private void ApplyHit(WeaponAttackSO action)
@@ -146,7 +150,7 @@ public class WeaponBase: MonoBehaviour
     private float GetFallbackHitDelay(WeaponAttackSO action)
     {
         if (action == null) return 0f;
-        return Mathf.Max(0f, action.EffectDelay) + Mathf.Max(0f, action.ActiveDelay);
+        return Mathf.Max(0f, action.ActiveDelay);
     }
 
     public void ActiveWeapon(bool isActive)
@@ -163,6 +167,23 @@ public class WeaponBase: MonoBehaviour
     public WeaponAttackSO GetCurrentAttackAction()
     {
         return GetAttackAction(m_attackCount);
+    }
+
+    public int GetCurrentAttackSequence()
+    {
+        return m_attackSequence;
+    }
+
+    public bool IsCurrentAttack(WeaponAttackSO action, int attackSequence)
+    {
+        return m_hasPendingHit && IsAttackSequenceCurrent(action, attackSequence);
+    }
+
+    public bool IsAttackSequenceCurrent(WeaponAttackSO action, int attackSequence)
+    {
+        return action != null &&
+               action == m_pendingAction &&
+               attackSequence == m_attackSequence;
     }
 
     public bool TryGetLastHitPosition(out Vector3 position)

--- a/Assets/Scripts/UI/InventorySystem.cs
+++ b/Assets/Scripts/UI/InventorySystem.cs
@@ -129,7 +129,10 @@ public class InventorySystem : UIElementBase
         // Equip -> Unequip로 아이템 전송 (장착 해제)
         else
         {
-            var res = UnequipSlots.First(slot => slot.SlotItem == null);
+            if (from.SlotItem == null) return;
+
+            var res = UnequipSlots.FirstOrDefault(slot => slot.SlotItem == null);
+            if (res == null) return;
 
             // 스탯 갱신
             if (from.SlotItem.ModifierStats != null)

--- a/Assets/Scripts/UI/InventorySystem.cs
+++ b/Assets/Scripts/UI/InventorySystem.cs
@@ -161,6 +161,8 @@ public class InventorySystem : UIElementBase
 
     public bool TryAddItem(InventoryItem item)
     {
+        if (item == null) return false;
+
         foreach (var slot in UnequipSlots)
         {
             if (slot.SlotItem == null)
@@ -170,6 +172,11 @@ public class InventorySystem : UIElementBase
             }
         }
         return false;
+    }
+
+    public bool HasEmptySlot()
+    {
+        return UnequipSlots.Any(slot => slot != null && slot.SlotItem == null);
     }
 
     private void UpdateDescription(InventoryItem item)

--- a/Assets/Scripts/UI/InventorySystem.cs
+++ b/Assets/Scripts/UI/InventorySystem.cs
@@ -22,7 +22,7 @@ public class InventorySystem : UIElementBase
 
     private void OnEnable()
     {
-        Controller.ChangeState(UIState.Inventory);
+        if (Controller == null || Controller.Player == null) return;
         var model = Controller.Player.model;
         if (model != null)
         {
@@ -38,6 +38,12 @@ public class InventorySystem : UIElementBase
 
     protected override void OnDisable()
     {
+        if (Controller == null || Controller.Player == null)
+        {
+            base.OnDisable();
+            return;
+        }
+
         var model = Controller.Player.model;
         if (model != null)
         {

--- a/Assets/Scripts/UI/InventorySystem.cs
+++ b/Assets/Scripts/UI/InventorySystem.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TMPro;
-using Unity.VisualScripting.Antlr3.Runtime.Misc;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -97,20 +96,20 @@ public class InventorySystem : UIElementBase
     public void SwapItem(ItemSlot from)
     {
         var model = Controller.Player.model;
-        // Unequip -> Equip·Î ¾ÆÀÌÅÛ Àü¼Û
+        // Unequip -> Equipë¡œ ì•„ì´í…œ ì „ì†¡
         if (from.SlotType == ItemType.None)
         {
-            // °°Àº ¾ÆÀÌÅÛ Å¸ÀÔÀÇ Equip ½½·Ô°ú Swap (Å¸ÀÔ º° Equip ½½·ÔÀº ÇÏ³ª)
+            // ê°™ì€ ì•„ì´í…œ íƒ€ìž…ì˜ Equip ìŠ¬ë¡¯ê³¼ Swap (íƒ€ìž… ë³„ Equip ìŠ¬ë¡¯ì€ í•˜ë‚˜)
 
             if (from.SlotItem!= null && equipDic.ContainsKey(from.SlotItem.ItemType))
             {
                 var equipSlot = equipDic[from.SlotItem.ItemType];
-                // ½ºÅÈ °»½Å
+                // ìŠ¤íƒ¯ ê°±ì‹ 
                 if (equipSlot.SlotItem != null)
                 {
                     foreach (var modifyStat in equipSlot.SlotItem.ModifierStats)
                     {
-                        // ±âÁ¸ ÀåÂøµÈ ¹«±âÀÇ ½ºÅÈÀÇ °ªÀº »©±â
+                        // ê¸°ì¡´ ìž¥ì°©ëœ ë¬´ê¸°ì˜ ìŠ¤íƒ¯ì˜ ê°’ì€ ë¹¼ê¸°
                         model.Stats[modifyStat.StatType].AddModifier(-modifyStat.StatModifier, StatModifyType.Equipment);
                     }
                 }
@@ -118,26 +117,26 @@ public class InventorySystem : UIElementBase
                 {
                     foreach (var modifyStat in from.SlotItem.ModifierStats)
                     {
-                        // »õ·Î ÀåÂøÇÒ ¹«±âÀÇ ½ºÅÈÀÇ °ªÀº ´õÇÏ±â
+                        // ìƒˆë¡œ ìž¥ì°©í•  ë¬´ê¸°ì˜ ìŠ¤íƒ¯ì˜ ê°’ì€ ë”í•˜ê¸°
                         model.Stats[modifyStat.StatType].AddModifier(modifyStat.StatModifier, StatModifyType.Equipment);
                     }
 
                 }
-                // ½º¿Ò
+                // ìŠ¤ì™‘
                 (from.SlotItem, equipSlot.SlotItem) = (equipSlot.SlotItem, from.SlotItem);
             }
         }
-        // Equip -> Unequip·Î ¾ÆÀÌÅÛ Àü¼Û (ÀåÂø ÇØÁ¦)
+        // Equip -> Unequipë¡œ ì•„ì´í…œ ì „ì†¡ (ìž¥ì°© í•´ì œ)
         else
         {
             var res = UnequipSlots.First(slot => slot.SlotItem == null);
 
-            // ½ºÅÈ °»½Å
+            // ìŠ¤íƒ¯ ê°±ì‹ 
             if (from.SlotItem.ModifierStats != null)
             {
                 foreach (var modifyStat in from.SlotItem.ModifierStats)
                 {
-                    // ±âÁ¸ ÀåÂøµÈ ¹«±âÀÇ ½ºÅÈÀÇ °ªÀº »©±â
+                    // ê¸°ì¡´ ìž¥ì°©ëœ ë¬´ê¸°ì˜ ìŠ¤íƒ¯ì˜ ê°’ì€ ë¹¼ê¸°
                     model.Stats[modifyStat.StatType].AddModifier(-modifyStat.StatModifier, StatModifyType.Equipment);
                 }
             }
@@ -145,7 +144,7 @@ public class InventorySystem : UIElementBase
             (from.SlotItem, res.SlotItem) = (res.SlotItem, from.SlotItem);
         }
 
-        // Unequip ½½·Ô Á¤·Ä
+        // Unequip ìŠ¬ë¡¯ ì •ë ¬
         var sortedItems = UnequipSlots
             .Select(slot => slot.SlotItem)
             .OrderBy(item => item == null)

--- a/Assets/Scripts/UI/ItemSlot.cs
+++ b/Assets/Scripts/UI/ItemSlot.cs
@@ -36,9 +36,9 @@ public class ItemSlot : MonoBehaviour, IPointerDownHandler,IPointerEnterHandler,
 
     public void OnPointerDown(PointerEventData eventData)
     {
-        if (Time.time - clickTime > clickDelay) clickCount = 0;
+        if (Time.unscaledTime - clickTime > clickDelay) clickCount = 0;
         clickCount++;
-        clickTime = Time.time;
+        clickTime = Time.unscaledTime;
         // 슬롯 아이템 스왑 (SlotType에 따라, Equip, Unequip 구분)
         if (clickCount > 1)
         {

--- a/Assets/Scripts/UI/RadialMenu.cs
+++ b/Assets/Scripts/UI/RadialMenu.cs
@@ -2,6 +2,7 @@ using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 public class RadialMenu : UIElementBase
@@ -31,7 +32,7 @@ public class RadialMenu : UIElementBase
 
     protected override void OnDisable()
     {
-        if (m_lastSelect >= contents.Length || m_lastSelect < 0) return;
+        if (contents == null || m_lastSelect >= contents.Length || m_lastSelect < 0) return;
 
         contents[m_lastSelect].Icon.localScale = m_lastIconOriginScale;
         Text.text = "";
@@ -39,7 +40,9 @@ public class RadialMenu : UIElementBase
     // Update is called once per frame
     void Update()
     {
-        Vector2 mousePos = Input.mousePosition;
+        if (contents == null || contents.Length == 0 || Mouse.current == null) return;
+
+        Vector2 mousePos = Mouse.current.position.ReadValue();
         var dir = mousePos - m_center;
 
         // 일정 거리 이내일 때는 버튼 동작 안함
@@ -54,11 +57,12 @@ public class RadialMenu : UIElementBase
 
         OverlayIcon(select);
 
-        if (Input.GetMouseButtonDown(0) 
+        if (Mouse.current.leftButton.wasPressedThisFrame
             && m_lastSelect < contents.Length
-            && m_lastSelect > -1
-            && contents != null)
+            && m_lastSelect > -1)
         {
+            if (Controller == null) return;
+
             Controller.ChangeState(contents[m_lastSelect].ChangeState);
             gameObject.SetActive(false);
         }

--- a/Assets/Scripts/UI/RadialMenu.cs
+++ b/Assets/Scripts/UI/RadialMenu.cs
@@ -57,17 +57,20 @@ public class RadialMenu : UIElementBase
 
         OverlayIcon(select);
 
-        if (Mouse.current.leftButton.wasPressedThisFrame
-            && m_lastSelect < contents.Length
-            && m_lastSelect > -1)
-        {
-            if (Controller == null) return;
-
-            Controller.ChangeState(contents[m_lastSelect].ChangeState);
-            gameObject.SetActive(false);
-        }
     }
 
+
+    public bool TryGetSelectedState(out UIState state)
+    {
+        if (contents != null && m_lastSelect >= 0 && m_lastSelect < contents.Length)
+        {
+            state = contents[m_lastSelect].ChangeState;
+            return true;
+        }
+
+        state = UIState.None;
+        return false;
+    }
     void OverlayIcon(int idx)
     {
         if (contents.Length <= idx || m_lastSelect == idx) return;

--- a/Assets/Scripts/UI/RadialMenu.cs
+++ b/Assets/Scripts/UI/RadialMenu.cs
@@ -16,6 +16,7 @@ public class RadialMenu : UIElementBase
 
     public MenuContent[] contents;
     public float IconOvelayMagnitude;
+    [Min(0f)] public float SelectionDistance = 100f;
     public TextMeshProUGUI Text;
 
     private Vector2 m_center;
@@ -25,6 +26,7 @@ public class RadialMenu : UIElementBase
     void OnEnable()
     {
         m_lastSelect = -1;
+        if (Text != null) Text.text = "";
         var pos = GetComponent<RectTransform>().position;
         // Recttransform에 맞게 스크린 위치 좌표
         m_center = RectTransformUtility.WorldToScreenPoint(null, pos);
@@ -32,10 +34,8 @@ public class RadialMenu : UIElementBase
 
     protected override void OnDisable()
     {
-        if (contents == null || m_lastSelect >= contents.Length || m_lastSelect < 0) return;
-
-        contents[m_lastSelect].Icon.localScale = m_lastIconOriginScale;
-        Text.text = "";
+        ClearSelection();
+        base.OnDisable();
     }
     // Update is called once per frame
     void Update()
@@ -46,7 +46,11 @@ public class RadialMenu : UIElementBase
         var dir = mousePos - m_center;
 
         // 일정 거리 이내일 때는 버튼 동작 안함
-        if (dir.sqrMagnitude < 100) return;
+        if (dir.sqrMagnitude < SelectionDistance * SelectionDistance)
+        {
+            ClearSelection();
+            return;
+        }
 
         // 45도 회전
         var deg = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg + 135f;
@@ -70,6 +74,18 @@ public class RadialMenu : UIElementBase
 
         state = UIState.None;
         return false;
+    }
+
+    private void ClearSelection()
+    {
+        if (contents != null && m_lastSelect >= 0 && m_lastSelect < contents.Length)
+        {
+            var icon = contents[m_lastSelect].Icon;
+            if (icon != null) icon.localScale = m_lastIconOriginScale;
+        }
+
+        m_lastSelect = -1;
+        if (Text != null) Text.text = "";
     }
     void OverlayIcon(int idx)
     {

--- a/Assets/Scripts/UI/SkillSlotManager.cs
+++ b/Assets/Scripts/UI/SkillSlotManager.cs
@@ -17,7 +17,7 @@ public class SkillSlotManager : MonoBehaviour
 
     public void RefreshSkillSlot(SkillBase skill, int slotIndex)
     {
-        if (slotIndex < 0 || slotIndex > (int)InputSkill.SkillE) return;
+        if (skill == null || slotIndex < 0 || slotIndex >= (int)InputSkill.Size) return;
 
         EquipSkillSlots[slotIndex].sprite = skill.Icon;
         var viewSlots = SlotView.slotContents;

--- a/Assets/Scripts/UI/SkillSlotManager.cs
+++ b/Assets/Scripts/UI/SkillSlotManager.cs
@@ -7,6 +7,21 @@ public class SkillSlotManager : MonoBehaviour
     public Image[] EquipSkillSlots;
     public SkillSlotView SlotView;
 
+    private Sprite[] m_defaultEquipSprites;
+    private Sprite[] m_defaultViewSprites;
+
+    private void Awake()
+    {
+        m_defaultEquipSprites = CaptureSprites(EquipSkillSlots);
+
+        var viewSlots = SlotView != null ? SlotView.slotContents : null;
+        m_defaultViewSprites = new Sprite[viewSlots?.Length ?? 0];
+        for (var index = 0; index < m_defaultViewSprites.Length; index++)
+        {
+            m_defaultViewSprites[index] = viewSlots[index].SlotImage?.sprite;
+        }
+    }
+
     private void OnEnable()
     {
         if (SlotView == null
@@ -17,10 +32,35 @@ public class SkillSlotManager : MonoBehaviour
 
     public void RefreshSkillSlot(SkillBase skill, int slotIndex)
     {
-        if (skill == null || slotIndex < 0 || slotIndex >= (int)InputSkill.Size) return;
+        if (slotIndex < 0 || slotIndex >= (int)InputSkill.Size) return;
 
-        EquipSkillSlots[slotIndex].sprite = skill.Icon;
+        var icon = skill != null ? skill.Icon : GetDefaultSprite(m_defaultEquipSprites, slotIndex);
+        if (EquipSkillSlots[slotIndex] != null)
+            EquipSkillSlots[slotIndex].sprite = icon;
+
         var viewSlots = SlotView.slotContents;
-        viewSlots[slotIndex].SlotImage.sprite = skill.Icon;
+        if (viewSlots[slotIndex].SlotImage != null)
+        {
+            viewSlots[slotIndex].SlotImage.sprite = skill != null
+                ? skill.Icon
+                : GetDefaultSprite(m_defaultViewSprites, slotIndex);
+        }
+    }
+
+    private static Sprite[] CaptureSprites(Image[] images)
+    {
+        var sprites = new Sprite[images?.Length ?? 0];
+        for (var index = 0; index < sprites.Length; index++)
+        {
+            sprites[index] = images[index]?.sprite;
+        }
+        return sprites;
+    }
+
+    private static Sprite GetDefaultSprite(Sprite[] sprites, int index)
+    {
+        return sprites != null && index >= 0 && index < sprites.Length
+            ? sprites[index]
+            : null;
     }
 }

--- a/Assets/Scripts/UI/SkillSlotView.cs
+++ b/Assets/Scripts/UI/SkillSlotView.cs
@@ -38,20 +38,25 @@ public class SkillSlotView : MonoBehaviour
     {
         if (Combat != null)
         {
-            if (Combat.skills.Count != slotContents.Length) return;
-
             var skills = Combat.skills;
-            for (int i = 0; i < skills.Count; i++)
+            for (int i = 0; i < slotContents.Length; i++)
             {
-                if (skills[i] != null && skills[i].CanUseSkill(Combat, m_mana, false))
+                var skill = i < skills.Count ? skills[i] : null;
+                var canUse = skill != null &&
+                             Combat.CanUseEquippedSkill(skill) &&
+                             skill.CanUseSkill(Combat, m_mana, false);
+
+                if (canUse)
                 {
                     slotContents[i].Animator?.SetBool(animParam, true);
-                    slotContents[i].SlotImage.color = Color.white;
+                    if (slotContents[i].SlotImage != null)
+                        slotContents[i].SlotImage.color = Color.white;
                 }
                 else
                 {
                     slotContents[i].Animator?.SetBool(animParam, false);
-                    slotContents[i].SlotImage.color = new Color(0.5f, 0.5f, 0.5f);
+                    if (slotContents[i].SlotImage != null)
+                        slotContents[i].SlotImage.color = new Color(0.5f, 0.5f, 0.5f);
                 }
             }
         }

--- a/Assets/Scripts/UI/SkillSlotView.cs
+++ b/Assets/Scripts/UI/SkillSlotView.cs
@@ -43,7 +43,7 @@ public class SkillSlotView : MonoBehaviour
             var skills = Combat.skills;
             for (int i = 0; i < skills.Count; i++)
             {
-                if (skills[i] != null && skills[i].CanUseSkill(m_mana, false))
+                if (skills[i] != null && skills[i].CanUseSkill(Combat, m_mana, false))
                 {
                     slotContents[i].Animator?.SetBool(animParam, true);
                     slotContents[i].SlotImage.color = Color.white;

--- a/Assets/Scripts/UI/SkillTreeSlot.cs
+++ b/Assets/Scripts/UI/SkillTreeSlot.cs
@@ -10,7 +10,7 @@ public class SkillTreeSlot : MonoBehaviour, IPointerDownHandler
 
     private void Start()
     {
-        if (SlotIcon != null) SlotIcon.sprite = SlotSkill.Icon;
+        if (SlotIcon != null && SlotSkill != null) SlotIcon.sprite = SlotSkill.Icon;
 
         RefreshSlot();
     }
@@ -22,9 +22,17 @@ public class SkillTreeSlot : MonoBehaviour, IPointerDownHandler
 
     public void RefreshSlot()
     {
-        // 비활성화 스킬은 색 어둡게
-        if (SlotSkill.CanActive == false) SlotIcon.color = new Color(0.5f, 0.5f, 0.5f);
-        // 구매 불가능 스킬은 검정색
-        if (SlotSkill.CanUnlock == false) SlotIcon.color = Color.black;
+        if (SlotSkill == null || SlotIcon == null || System == null) return;
+
+        var state = System.GetSkillState(SlotSkill);
+        if (System.IsSkillUnlocked(SlotSkill) == false)
+        {
+            SlotIcon.color = Color.black;
+            return;
+        }
+
+        SlotIcon.color = state != null && state.IsActive
+            ? Color.white
+            : new Color(0.5f, 0.5f, 0.5f);
     }
 }

--- a/Assets/Scripts/UI/SkillTreeSystem.cs
+++ b/Assets/Scripts/UI/SkillTreeSystem.cs
@@ -19,6 +19,7 @@ public class SkillTreeSystem : UIElementBase
 
     private SkillTreeSlot m_clickedSkillSlot;
     private PlayerCombat m_combat;
+    private InputAction m_skillEquipAction;
 
     private void Start()
     {
@@ -31,12 +32,13 @@ public class SkillTreeSystem : UIElementBase
         if (Controller == null || Controller.Player == null) return;
 
         ResolveCombat();
-        Controller.ChangeState(UIState.SkillTree);
         EquipBtn?.onClick.AddListener(EquipSkill);
         EnforceBtn?.onClick.AddListener(EnforceSkill);
         if (Controller.Player.input?.actions != null)
         {
-            Controller.Player.input.actions["Skill"].performed += OnSkillEquip;
+            m_skillEquipAction = Controller.Player.input.actions.FindAction("UI/Skill");
+            if (m_skillEquipAction != null)
+                m_skillEquipAction.performed += OnSkillEquip;
         }
         RefreshAllSlots();
     }
@@ -45,9 +47,10 @@ public class SkillTreeSystem : UIElementBase
     {
         if (Controller != null &&
             Controller.Player != null &&
-            Controller.Player.input?.actions != null)
+            Controller.Player.input?.actions != null &&
+            m_skillEquipAction != null)
         {
-            Controller.Player.input.actions["Skill"].performed -= OnSkillEquip;
+            m_skillEquipAction.performed -= OnSkillEquip;
         }
 
         EquipBtn?.onClick.RemoveListener(EquipSkill);

--- a/Assets/Scripts/UI/SkillTreeSystem.cs
+++ b/Assets/Scripts/UI/SkillTreeSystem.cs
@@ -20,6 +20,8 @@ public class SkillTreeSystem : UIElementBase
     private SkillTreeSlot m_clickedSkillSlot;
     private PlayerCombat m_combat;
     private InputAction m_skillEquipAction;
+    private bool m_runtimeEquipListener;
+    private bool m_runtimeEnforceListener;
 
     private void Start()
     {
@@ -32,8 +34,8 @@ public class SkillTreeSystem : UIElementBase
         if (Controller == null || Controller.Player == null) return;
 
         ResolveCombat();
-        EquipBtn?.onClick.AddListener(EquipSkill);
-        EnforceBtn?.onClick.AddListener(EnforceSkill);
+        m_runtimeEquipListener = AddListenerWhenMissing(EquipBtn, nameof(EquipSkill), EquipSkill);
+        m_runtimeEnforceListener = AddListenerWhenMissing(EnforceBtn, nameof(EnforceSkill), EnforceSkill);
         if (Controller.Player.input?.actions != null)
         {
             m_skillEquipAction = Controller.Player.input.actions.FindAction("UI/Skill");
@@ -53,9 +55,30 @@ public class SkillTreeSystem : UIElementBase
             m_skillEquipAction.performed -= OnSkillEquip;
         }
 
-        EquipBtn?.onClick.RemoveListener(EquipSkill);
-        EnforceBtn?.onClick.RemoveListener(EnforceSkill);
+        if (m_runtimeEquipListener)
+            EquipBtn?.onClick.RemoveListener(EquipSkill);
+        if (m_runtimeEnforceListener)
+            EnforceBtn?.onClick.RemoveListener(EnforceSkill);
+        m_runtimeEquipListener = false;
+        m_runtimeEnforceListener = false;
         base.OnDisable();
+    }
+
+    private bool AddListenerWhenMissing(Button button, string methodName, UnityEngine.Events.UnityAction action)
+    {
+        if (button == null) return false;
+
+        for (var index = 0; index < button.onClick.GetPersistentEventCount(); index++)
+        {
+            if (button.onClick.GetPersistentTarget(index) == this &&
+                button.onClick.GetPersistentMethodName(index) == methodName)
+            {
+                return false;
+            }
+        }
+
+        button.onClick.AddListener(action);
+        return true;
     }
 
     public void ClickDescriptionWindow(SkillTreeSlot slot, bool isActive)
@@ -154,6 +177,14 @@ public class SkillTreeSystem : UIElementBase
         if (m_combat.skills.Count < size)
         {
             m_combat.skills.AddRange(Enumerable.Repeat<SkillBase>(null, size - m_combat.skills.Count));
+        }
+
+        for (var index = 0; index < size; index++)
+        {
+            if (index == bindingIndex || m_combat.skills[index] != selectedSkill) continue;
+
+            m_combat.skills[index] = null;
+            SkillSlots.RefreshSkillSlot(null, index);
         }
 
         m_combat.skills[bindingIndex] = selectedSkill;

--- a/Assets/Scripts/UI/SkillTreeSystem.cs
+++ b/Assets/Scripts/UI/SkillTreeSystem.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using TMPro;
-using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
@@ -19,162 +17,185 @@ public class SkillTreeSystem : UIElementBase
     public Button EnforceBtn;
     public TextMeshProUGUI EnforceBtnText;
 
-    // key: 선행스킬 value: 선행스킬을 요구하는 스킬들 
-    public Dictionary<SkillBase, List<SkillBase>> preRequireSkillDic;
     private SkillTreeSlot m_clickedSkillSlot;
+    private PlayerCombat m_combat;
 
     private void Start()
     {
-        preRequireSkillDic = new();
-        foreach (var slot in SkillTreeSlots)
-        {
-            foreach (var skill in slot.SlotSkill.RequireSkill)
-            {
-                if (!preRequireSkillDic.ContainsKey(skill))
-                {
-                    preRequireSkillDic[skill] = new List<SkillBase>();
-                }
-                preRequireSkillDic[skill].Add(slot.SlotSkill);
-            }
-        }
+        ResolveCombat();
+        RefreshAllSlots();
     }
 
     private void OnEnable()
     {
+        if (Controller == null || Controller.Player == null) return;
+
+        ResolveCombat();
         Controller.ChangeState(UIState.SkillTree);
-        EquipBtn.onClick.AddListener(EquipSkill);
-        EnforceBtn.onClick.AddListener(EnforceSkill);
-        Controller.Player.input.actions["Skill"].performed += OnSkillEquip;
+        EquipBtn?.onClick.AddListener(EquipSkill);
+        EnforceBtn?.onClick.AddListener(EnforceSkill);
+        if (Controller.Player.input?.actions != null)
+        {
+            Controller.Player.input.actions["Skill"].performed += OnSkillEquip;
+        }
+        RefreshAllSlots();
     }
 
     protected override void OnDisable()
     {
-        if (Controller.Player.IsDestroyed() == false)
+        if (Controller != null &&
+            Controller.Player != null &&
+            Controller.Player.input?.actions != null)
         {
             Controller.Player.input.actions["Skill"].performed -= OnSkillEquip;
         }
-        EquipBtn.onClick.RemoveListener(EquipSkill);
-        EnforceBtn.onClick.RemoveListener(EnforceSkill);
+
+        EquipBtn?.onClick.RemoveListener(EquipSkill);
+        EnforceBtn?.onClick.RemoveListener(EnforceSkill);
         base.OnDisable();
     }
-    public void ClickDescriptionWindow (SkillTreeSlot slot, bool isActive)
-    {
-        var skill = slot.SlotSkill;
-        if (skill.CanUnlock == false) return;
 
-        if (skill == null)
+    public void ClickDescriptionWindow(SkillTreeSlot slot, bool isActive)
+    {
+        var skill = slot?.SlotSkill;
+        if (skill == null || IsSkillUnlocked(skill) == false)
         {
-            DescriptionWindow.SetActive(false);
+            DescriptionWindow?.SetActive(false);
             return;
         }
+
         if (isActive)
         {
             m_clickedSkillSlot = slot;
             UpdateDescription();
             RefreshEnforceText();
-            // 착용 ui는 비활성화
-            SkillSlots.gameObject.SetActive(false);
-        }
-        else m_clickedSkillSlot = null;
-        DescriptionWindow.SetActive(isActive);
-    }
-
-
-    private void UpdateDescription()
-    {
-        var skill = m_clickedSkillSlot.SlotSkill;
-        if (DescriptionImage == null || DescriptionText == null || skill == null) return;
-        StringBuilder sb = new();
-        sb.AppendLine($"<color=#D0E8F2>[{skill.SkillName}]</color>");
-        sb.AppendLine(skill.Description);
-        sb.AppendLine();
-        foreach (var stat in skill.SkillStats)
-        {
-            sb.AppendLine($"{stat.StatType.ToString()}:");
-            sb.AppendLine($"  + Flat: {stat.StatModifier.FixedValue:F1}");
-            sb.AppendLine($"  + Percent: {stat.StatModifier.PercentValue:F1}");
-            sb.AppendLine($"  + Duration: {stat.Duration:F1}");
-        }
-        DescriptionText.text = sb.ToString();
-        DescriptionImage.sprite = skill.Icon;
-    }
-    public void EnforceSkill()
-    {
-        // 비활성화 여부에 따라 / 1. 활성화 / 2. 강화
-        var skill = m_clickedSkillSlot.SlotSkill;
-        if (skill == null || skill.CanUnlock == false) return;
-
-        var money = Controller.Player.model.Money;
-        var cost = skill.EnforceBaseCost * (1 + skill.EnforceLevel * skill.EnforceCostFactor);
-        if (money.TotalValue - cost < 0f) return;
-
-        if (skill.CanActive == false)
-        {
-            // 돈이 있는 경우 비용 지불과 동시에 활성화
-            skill.CanActive = true;
-            skill.EnforceLevel = 1;
-            m_clickedSkillSlot.SlotIcon.color = Color.white;
-            money.AddModifier(new StatModifier(-cost, 0), StatModifyType.Permanent);
-
-            // 선행스킬로 등록된 스킬들 검사
-            if (preRequireSkillDic.TryGetValue(skill,out var items))
-            {
-                // 리스트 내 스킬들의 각각의 선행스킬을 검사하여, Unlock여부 갱신
-                foreach (var item in items)
-                {
-                    item.UnlockRequireSkill(skill);
-                }
-            }
-
-            // 모든 검사가 끝나면 슬롯 업데이트
-            foreach (var item in SkillTreeSlots)
-            {
-                item.RefreshSlot();
-            }
-            RefreshEnforceText();
+            SkillSlots?.gameObject.SetActive(false);
         }
         else
         {
-            if (skill.EnforceCostFactor < 0) return;
-            skill.EnforceLevel++;
-            RefreshEnforceText();
+            m_clickedSkillSlot = null;
         }
+
+        DescriptionWindow?.SetActive(isActive);
+    }
+
+    private void UpdateDescription()
+    {
+        var skill = m_clickedSkillSlot?.SlotSkill;
+        if (DescriptionImage == null || DescriptionText == null || skill == null) return;
+
+        var builder = new StringBuilder();
+        builder.AppendLine($"<color=#D0E8F2>[{skill.SkillName}]</color>");
+        builder.AppendLine(skill.Description);
+        builder.AppendLine();
+
+        foreach (var stat in skill.SkillStats ?? System.Array.Empty<StatChange>())
+        {
+            builder.AppendLine($"{stat.StatType}:");
+            builder.AppendLine($"  + Flat: {stat.StatModifier.FixedValue:F1}");
+            builder.AppendLine($"  + Percent: {stat.StatModifier.PercentValue:F1}");
+            builder.AppendLine($"  + Duration: {stat.Duration:F1}");
+        }
+
+        DescriptionText.text = builder.ToString();
+        DescriptionImage.sprite = skill.Icon;
+    }
+
+    public void EnforceSkill()
+    {
+        var skill = m_clickedSkillSlot?.SlotSkill;
+        if (skill == null || IsSkillUnlocked(skill) == false || ResolveCombat() == false) return;
+
+        var state = m_combat.GetSkillState(skill);
+        if (state.IsActive && skill.EnforceCostFactor < 0f) return;
+
+        var cost = skill.GetEnforceCost(state);
+        var money = Controller?.Player?.model?.Money;
+        if (money == null) return;
+        if (money.TotalValue < cost) return;
+
+        money.AddModifier(new StatModifier(-cost, 0), StatModifyType.Permanent);
+        if (state.IsActive)
+        {
+            state.EnforceLevel++;
+        }
+        else
+        {
+            state.IsActive = true;
+            state.EnforceLevel = Mathf.Max(1, state.EnforceLevel);
+        }
+
+        RefreshAllSlots();
+        RefreshEnforceText();
     }
 
     public void EquipSkill()
     {
-        if (m_clickedSkillSlot.SlotSkill == null ||
-            m_clickedSkillSlot.SlotSkill.CanActive == false) return;
-        SkillSlots.gameObject.SetActive(true);
+        var skill = m_clickedSkillSlot?.SlotSkill;
+        if (skill == null || ResolveCombat() == false || m_combat.GetSkillState(skill).IsActive == false) return;
+
+        SkillSlots?.gameObject.SetActive(true);
     }
 
     public void OnSkillEquip(InputAction.CallbackContext context)
     {
-        var player = Controller.Player;
+        if (ResolveCombat() == false || SkillSlots == null || SkillSlots.gameObject.activeSelf == false) return;
+
         var size = (int)InputSkill.Size;
-        int bindingIndex = context.action.GetBindingIndexForControl(context.control);
-        if (bindingIndex < 0 || bindingIndex >= size || SkillSlots.gameObject.activeSelf == false) return;
+        var bindingIndex = context.action.GetBindingIndexForControl(context.control);
+        if (bindingIndex < 0 || bindingIndex >= size) return;
 
-        int currentCount = player.combat.skills.Count;
-        // 부족한 만큼 null값 추가하여 리스트 크기 맞추기
-        if (currentCount < size)
+        var selectedSkill = m_clickedSkillSlot?.SlotSkill;
+        if (selectedSkill == null || m_combat.GetSkillState(selectedSkill).IsActive == false) return;
+
+        if (m_combat.skills.Count < size)
         {
-            int diff = (int)InputSkill.Size - currentCount;
-            player.combat.skills.AddRange(Enumerable.Repeat<SkillBase>(null, diff));
+            m_combat.skills.AddRange(Enumerable.Repeat<SkillBase>(null, size - m_combat.skills.Count));
         }
-        player.combat.skills[bindingIndex] = m_clickedSkillSlot.SlotSkill;
-        
-        SkillSlots.RefreshSkillSlot(m_clickedSkillSlot.SlotSkill, bindingIndex);
-        SkillSlots.gameObject.SetActive(false);
 
+        m_combat.skills[bindingIndex] = selectedSkill;
+        SkillSlots.RefreshSkillSlot(selectedSkill, bindingIndex);
+        SkillSlots.gameObject.SetActive(false);
     }
+
     public void RefreshEnforceText()
     {
-        if (m_clickedSkillSlot == null) return;
-        var skill = m_clickedSkillSlot.SlotSkill;
-        if (EnforceBtnText == null || skill == null) return;
-        // 해금되었으면서 강화 비용 없는 경우 Max
-        if (skill.CanActive && skill.EnforceCostFactor < 0) EnforceBtnText.text = "Max";
-        else EnforceBtnText.text = (skill.EnforceBaseCost * (1 + skill.EnforceLevel * skill.EnforceCostFactor)).ToString();
+        var skill = m_clickedSkillSlot?.SlotSkill;
+        if (EnforceBtnText == null || skill == null || ResolveCombat() == false) return;
+
+        var state = m_combat.GetSkillState(skill);
+        EnforceBtnText.text = state.IsActive && skill.EnforceCostFactor < 0f
+            ? "Max"
+            : skill.GetEnforceCost(state).ToString();
+    }
+
+    public SkillRuntimeState GetSkillState(SkillBase skill)
+    {
+        return ResolveCombat() ? m_combat.GetSkillState(skill) : null;
+    }
+
+    public bool IsSkillUnlocked(SkillBase skill)
+    {
+        return ResolveCombat() && m_combat.IsSkillUnlocked(skill);
+    }
+
+    private bool ResolveCombat()
+    {
+        if (m_combat == null)
+        {
+            m_combat = Controller?.Player?.combat;
+        }
+
+        return m_combat != null;
+    }
+
+    private void RefreshAllSlots()
+    {
+        if (SkillTreeSlots == null) return;
+
+        foreach (var slot in SkillTreeSlots)
+        {
+            slot?.RefreshSlot();
+        }
     }
 }

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -20,6 +20,9 @@ public class UIController : ManagerBase<UIController>
     private bool m_isInitialized;
     private InputAction m_radialMenuAction;
     private InputAction m_exitAction;
+    private CanvasGroup m_noticeGroup;
+    private TextMeshProUGUI m_noticeText;
+    private DG.Tweening.Sequence m_noticeSequence;
     public UIState CurrentState => m_currentState;
 
     private void Start()
@@ -35,6 +38,7 @@ public class UIController : ManagerBase<UIController>
         }
 
         ChangeState(UIState.None);
+        InitializeNotice();
         IsReady = true;
     }
     public override void StartInit()
@@ -103,14 +107,14 @@ public class UIController : ManagerBase<UIController>
                 element.gameObject.SetActive(true);
             else if (context.canceled)
             {
-                if (element is RadialMenu radialMenu &&
-                    radialMenu.TryGetSelectedState(out var selectedState))
+                var selectedState = UIState.None;
+                var hasSelection = element is RadialMenu radialMenu &&
+                                   radialMenu.TryGetSelectedState(out selectedState);
+                element.gameObject.SetActive(false);
+
+                if (hasSelection)
                 {
                     ChangeState(selectedState);
-                }
-                else
-                {
-                    element.gameObject.SetActive(false);
                 }
             }
         }
@@ -144,6 +148,87 @@ public class UIController : ManagerBase<UIController>
     {
         KillText.text = $"{newKill} Kill";
     }
+
+    public void ShowRequiredWeaponMessage(WeaponType weaponType)
+    {
+        var weaponName = weaponType switch
+        {
+            WeaponType.Sword => "검",
+            WeaponType.Knife => "단검",
+            _ => "알맞은 무기",
+        };
+
+        ShowNotice($"{weaponName}을 장착해야 스킬을 사용할 수 있습니다.");
+    }
+
+    private void InitializeNotice()
+    {
+        if (m_noticeGroup != null) return;
+
+        var noticeObject = new GameObject(
+            "SkillNotice",
+            typeof(RectTransform),
+            typeof(CanvasGroup),
+            typeof(Image));
+        noticeObject.transform.SetParent(transform, false);
+        noticeObject.transform.SetAsLastSibling();
+
+        var noticeRect = noticeObject.GetComponent<RectTransform>();
+        noticeRect.anchorMin = new Vector2(0.5f, 0.22f);
+        noticeRect.anchorMax = new Vector2(0.5f, 0.22f);
+        noticeRect.pivot = new Vector2(0.5f, 0.5f);
+        noticeRect.anchoredPosition = Vector2.zero;
+        noticeRect.sizeDelta = new Vector2(500f, 48f);
+
+        var background = noticeObject.GetComponent<Image>();
+        background.color = new Color(0.05f, 0.05f, 0.05f, 0.82f);
+        background.raycastTarget = false;
+
+        m_noticeGroup = noticeObject.GetComponent<CanvasGroup>();
+        m_noticeGroup.alpha = 0f;
+        m_noticeGroup.interactable = false;
+        m_noticeGroup.blocksRaycasts = false;
+
+        var textObject = new GameObject(
+            "Text",
+            typeof(RectTransform),
+            typeof(TextMeshProUGUI));
+        textObject.transform.SetParent(noticeObject.transform, false);
+
+        var textRect = textObject.GetComponent<RectTransform>();
+        textRect.anchorMin = Vector2.zero;
+        textRect.anchorMax = Vector2.one;
+        textRect.offsetMin = new Vector2(16f, 4f);
+        textRect.offsetMax = new Vector2(-16f, -4f);
+
+        m_noticeText = textObject.GetComponent<TextMeshProUGUI>();
+        m_noticeText.font = MoneyText != null ? MoneyText.font : KillText?.font;
+        m_noticeText.alignment = TextAlignmentOptions.Center;
+        m_noticeText.color = Color.white;
+        m_noticeText.fontSize = 22f;
+        m_noticeText.enableAutoSizing = true;
+        m_noticeText.fontSizeMin = 14f;
+        m_noticeText.fontSizeMax = 22f;
+        m_noticeText.raycastTarget = false;
+    }
+
+    private void ShowNotice(string message)
+    {
+        InitializeNotice();
+        if (m_noticeGroup == null || m_noticeText == null) return;
+
+        m_noticeText.text = message;
+        m_noticeGroup.transform.SetAsLastSibling();
+        m_noticeSequence?.Kill();
+        m_noticeGroup.alpha = 0f;
+
+        m_noticeSequence = DOTween.Sequence()
+            .SetUpdate(true)
+            .Append(m_noticeGroup.DOFade(1f, 0.12f))
+            .AppendInterval(1.25f)
+            .Append(m_noticeGroup.DOFade(0f, 0.22f));
+    }
+
     public void DeadUI(float duration)
     {
         ChangeState(UIState.Die);

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -17,6 +17,7 @@ public class UIController : ManagerBase<UIController>
     public TextMeshProUGUI MoneyText;
 
     private UIState m_currentState;
+    private bool m_isInitialized;
     public UIState CurrentState => m_currentState;
 
     private void Start()
@@ -31,17 +32,12 @@ public class UIController : ManagerBase<UIController>
             UIElements[element.Type] = element;
         }
 
-        var instance = InGameLoop.Instance;
-        if (instance != null)
-        {
-            instance.KillCount.OnValueChanged += OnKillChanged;
-            OnKillChanged(instance.KillCount.Value);
-        }
         IsReady = true;
     }
     public override void StartInit()
     {
         base.StartInit();
+        if (m_isInitialized) return;
         if (Player == null || Player.input == null || Player.input.actions == null || Player.model == null) return;
 
         Player.input.actions["RadialMenu"].performed += OnRadialMenu;
@@ -51,6 +47,16 @@ public class UIController : ManagerBase<UIController>
         Player.model.Mana.OnChangeStat += OnMPChanged;
         Player.model.Money.OnChangeStat += OnMoneyChanged;
 
+        var instance = InGameLoop.Instance;
+        if (instance?.KillCount != null)
+        {
+            instance.KillCount.OnValueChanged += OnKillChanged;
+            OnKillChanged(instance.KillCount.Value);
+        }
+
+        m_isInitialized = true;
+        OnHPChanged();
+        OnMPChanged();
         OnMoneyChanged();
     }
     private void OnDisable()
@@ -65,10 +71,11 @@ public class UIController : ManagerBase<UIController>
             Player.model.Money.OnChangeStat -= OnMoneyChanged;
         }
 
-        if (InGameLoop.Instance != null)
+        if (InGameLoop.Instance?.KillCount != null)
         {
             InGameLoop.Instance.KillCount.OnValueChanged -= OnKillChanged;
         }
+        m_isInitialized = false;
     }
 
     public void OnRadialMenu(InputAction.CallbackContext context)

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -50,6 +50,8 @@ public class UIController : ManagerBase<UIController>
         Player.model.Health.OnChangeStat += OnHPChanged;
         Player.model.Mana.OnChangeStat += OnMPChanged;
         Player.model.Money.OnChangeStat += OnMoneyChanged;
+
+        OnMoneyChanged();
     }
     private void OnDisable()
     {
@@ -101,6 +103,8 @@ public class UIController : ManagerBase<UIController>
     }
     public void OnMoneyChanged()
     {
+        if (Player == null || Player.model == null || MoneyText == null) return;
+
         var money = Player.model.Money;
         MoneyText.text = $"{money.TotalValue} $";
     }
@@ -118,7 +122,7 @@ public class UIController : ManagerBase<UIController>
             var texts = element.GetComponentsInChildren<TextMeshProUGUI>(true);
             var btns = element.GetComponentsInChildren<Button>(true);
 
-            // 원래 색상 저장 및 알파값 0으로 설정
+            // Store original colors and start fully transparent.
             Color[] imgsOriginalAlphas = new Color[imgs.Length];
             Color[] textsOriginalAlphas = new Color[texts.Length];
             float[] btnsOriginalAlphas = new float[btns.Length];
@@ -143,7 +147,7 @@ public class UIController : ManagerBase<UIController>
                 btns[i].interactable = false;
             }
 
-            // 모든 요소 duration동안 동시에 Fade
+            // Fade all elements together.
             DG.Tweening.Sequence seq = DOTween.Sequence();
             seq.SetUpdate(true);
 
@@ -156,7 +160,7 @@ public class UIController : ManagerBase<UIController>
                 seq.Join(texts[i].DOColor(textsOriginalAlphas[i], duration));
             }
 
-            // 완료후 버튼 활성화
+            // Enable buttons after the fade completes.
             seq.OnComplete(() =>
             {
                 for (int i = 0; i < btns.Length; i++)
@@ -173,7 +177,7 @@ public class UIController : ManagerBase<UIController>
     {
         m_currentState = state;
 
-        // 만약, ui전용 패널이 열릴 경우 ui키입력으로 상태 전환
+        // Switch input maps while a UI-only panel is open.
         
         if (state == UIState.None)
         {

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -18,6 +18,8 @@ public class UIController : ManagerBase<UIController>
 
     private UIState m_currentState;
     private bool m_isInitialized;
+    private InputAction m_radialMenuAction;
+    private InputAction m_exitAction;
     public UIState CurrentState => m_currentState;
 
     private void Start()
@@ -32,6 +34,7 @@ public class UIController : ManagerBase<UIController>
             UIElements[element.Type] = element;
         }
 
+        ChangeState(UIState.None);
         IsReady = true;
     }
     public override void StartInit()
@@ -40,9 +43,17 @@ public class UIController : ManagerBase<UIController>
         if (m_isInitialized) return;
         if (Player == null || Player.input == null || Player.input.actions == null || Player.model == null) return;
 
-        Player.input.actions["RadialMenu"].performed += OnRadialMenu;
-        Player.input.actions["RadialMenu"].canceled += OnRadialMenu;
-        Player.input.actions["Exit"].performed += OnExitPanel;
+        m_radialMenuAction = Player.input.actions.FindAction("Player/RadialMenu");
+        m_exitAction = Player.input.actions.FindAction("UI/Exit");
+        if (m_radialMenuAction == null || m_exitAction == null)
+        {
+            Debug.LogError("Required UI input actions are missing.", this);
+            return;
+        }
+
+        m_radialMenuAction.performed += OnRadialMenu;
+        m_radialMenuAction.canceled += OnRadialMenu;
+        m_exitAction.performed += OnExitPanel;
         Player.model.Health.OnChangeStat += OnHPChanged;
         Player.model.Mana.OnChangeStat += OnMPChanged;
         Player.model.Money.OnChangeStat += OnMoneyChanged;
@@ -61,11 +72,15 @@ public class UIController : ManagerBase<UIController>
     }
     private void OnDisable()
     {
-        if (Player != null && Player.IsDestroyed() == false)
+        if (m_isInitialized && Player != null && Player.IsDestroyed() == false)
         {
-            Player.input.actions["RadialMenu"].performed -= OnRadialMenu;
-            Player.input.actions["RadialMenu"].canceled -= OnRadialMenu;
-            Player.input.actions["Exit"].performed -= OnExitPanel;
+            if (m_radialMenuAction != null)
+            {
+                m_radialMenuAction.performed -= OnRadialMenu;
+                m_radialMenuAction.canceled -= OnRadialMenu;
+            }
+            if (m_exitAction != null)
+                m_exitAction.performed -= OnExitPanel;
             Player.model.Health.OnChangeStat -= OnHPChanged;
             Player.model.Mana.OnChangeStat -= OnMPChanged;
             Player.model.Money.OnChangeStat -= OnMoneyChanged;
@@ -182,31 +197,28 @@ public class UIController : ManagerBase<UIController>
 
     public void ChangeState(UIState state)
     {
+        if (UIElements == null) return;
+        if (state != UIState.None && UIElements.ContainsKey(state) == false)
+            state = UIState.None;
+
         m_currentState = state;
-
-        // Switch input maps while a UI-only panel is open.
-        
-        if (state == UIState.None)
+        foreach (var pair in UIElements)
         {
-            Time.timeScale = 1f;
-            foreach (var element in UIElements.Values)
-            {
-                if (element.DependencyOnChangeState)
-                    element.gameObject.SetActive(false);
-            }
-            Player?.SetActionMap(InputActionMap.Player);
-        }
-        else
-        {
-            Time.timeScale = 0f;
-            if (UIElements.TryGetValue(state, out var element))
-            {
-                if (element.DependencyOnChangeState)
-                    element.gameObject.SetActive(true);
-            }
-            else ChangeState(UIState.None);
+            var element = pair.Value;
+            if (element == null || element.DependencyOnChangeState == false) continue;
 
-            Player?.SetActionMap(state == UIState.Dialog ? InputActionMap.Dialog : InputActionMap.UI);
+            var shouldBeActive = state != UIState.None && pair.Key == state;
+            if (element.gameObject.activeSelf != shouldBeActive)
+                element.gameObject.SetActive(shouldBeActive);
         }
+
+        Time.timeScale = state == UIState.None ? 1f : 0f;
+        var inputMap = state switch
+        {
+            UIState.None => InputActionMap.Player,
+            UIState.Dialog => InputActionMap.Dialog,
+            _ => InputActionMap.UI,
+        };
+        Player?.SetActionMap(inputMap);
     }
 }

--- a/Assets/Scripts/UI/UIController.cs
+++ b/Assets/Scripts/UI/UIController.cs
@@ -102,7 +102,17 @@ public class UIController : ManagerBase<UIController>
             if (context.performed)
                 element.gameObject.SetActive(true);
             else if (context.canceled)
-                element.gameObject.SetActive(false);
+            {
+                if (element is RadialMenu radialMenu &&
+                    radialMenu.TryGetSelectedState(out var selectedState))
+                {
+                    ChangeState(selectedState);
+                }
+                else
+                {
+                    element.gameObject.SetActive(false);
+                }
+            }
         }
     }
 

--- a/Assets/Scripts/UI/UIElementBase.cs
+++ b/Assets/Scripts/UI/UIElementBase.cs
@@ -8,7 +8,5 @@ public class UIElementBase : MonoBehaviour
 
     protected virtual void OnDisable()
     {
-        if (Controller != null && Controller.CurrentState == Type)
-            Controller.ChangeState(UIState.None);
     }
 }

--- a/Assets/Scripts/UI/UIElementBase.cs
+++ b/Assets/Scripts/UI/UIElementBase.cs
@@ -8,5 +8,7 @@ public class UIElementBase : MonoBehaviour
 
     protected virtual void OnDisable()
     {
+        if (Controller != null && Controller.CurrentState == Type)
+            Controller.ChangeState(UIState.None);
     }
 }

--- a/Assets/VFXSyncHelper.cs
+++ b/Assets/VFXSyncHelper.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 public class VFXSyncHelper : MonoBehaviour
 {
     public PlayerCombat PlayerCombat;
+    private WeaponBase m_lastScheduledWeapon;
+    private int m_lastScheduledAttackSequence = -1;
 
     private void Start()
     {
@@ -23,19 +25,68 @@ public class VFXSyncHelper : MonoBehaviour
         var action = weapon.GetCurrentAttackAction();
         if (action == null) return;
 
-        weapon.ApplyAnimationEventHit();
+        var attackSequence = weapon.GetCurrentAttackSequence();
+        if (weapon == m_lastScheduledWeapon &&
+            attackSequence == m_lastScheduledAttackSequence)
+        {
+            return;
+        }
 
-        if (action.MainVFXPrefab != null || action.HitVFXPrefab != null)
-            PlayAttackActionVFX(action, weapon.transform);
+        m_lastScheduledWeapon = weapon;
+        m_lastScheduledAttackSequence = attackSequence;
+        StartCoroutine(PlayAttackActionVFX(weapon, action, attackSequence));
     }
 
-    private void PlayAttackActionVFX(WeaponAttackSO action, Transform weaponTransform)
+    private IEnumerator PlayAttackActionVFX(
+        WeaponBase weapon,
+        WeaponAttackSO action,
+        int attackSequence)
     {
-        if (action.MainVFXPrefab != null)
-            PlayPrefabVFX(action.MainVFXPrefab, action.GetMainVFXPosition(weaponTransform), action.GetMainVFXRotation(weaponTransform));
+        var weaponTransform = weapon.transform;
+        var hitDelay = Mathf.Max(0f, action.ActiveDelay);
+        var effectDelay = Mathf.Max(0f, action.EffectDelay);
+        var elapsed = 0f;
+        var hitResolved = false;
+        var effectResolved = false;
 
-        if (action.HitVFXPrefab != null && PlayerCombat.GetCurWeapon().TryGetLastHitPosition(out var hitPosition))
-            PlayPrefabVFX(action.HitVFXPrefab, action.GetHitVFXPosition(weaponTransform, hitPosition), action.GetHitVFXRotation(weaponTransform));
+        while (hitResolved == false || effectResolved == false)
+        {
+            if (weapon.IsAttackSequenceCurrent(action, attackSequence) == false)
+                yield break;
+
+            if (effectResolved == false && elapsed >= effectDelay)
+            {
+                effectResolved = true;
+                if (action.MainVFXPrefab != null)
+                {
+                    PlayPrefabVFX(
+                        action.MainVFXPrefab,
+                        action.GetMainVFXPosition(weaponTransform),
+                        action.GetMainVFXRotation(weaponTransform));
+                }
+            }
+
+            if (hitResolved == false && elapsed >= hitDelay)
+            {
+                hitResolved = true;
+                var hitSucceeded = weapon.ApplyAnimationEventHit(action, attackSequence);
+                if (hitSucceeded &&
+                    action.HitVFXPrefab != null &&
+                    weapon.TryGetLastHitPosition(out var hitPosition))
+                {
+                    PlayPrefabVFX(
+                        action.HitVFXPrefab,
+                        action.GetHitVFXPosition(weaponTransform, hitPosition),
+                        action.GetHitVFXRotation(weaponTransform));
+                }
+            }
+
+            if (hitResolved && effectResolved)
+                yield break;
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
     }
 
     private void PlayPrefabVFX(ParticleSystem prefab, Vector3 position, Quaternion rotation)


### PR DESCRIPTION
## 작업 내용
- 청크맵 생성·연결 보장 및 초기 플레이어 주변 로딩 안정화
- NavMesh 준비 이후 적 스폰·풀링·보스전 전환이 진행되도록 수명주기 정리
- 청크 렌더러 배칭, 맵 업데이트 분산, 순찰 지점 재사용 등 런타임 최적화
- 적 피격·사망·재사용 상태와 다중 콜라이더 피해 처리 안정화
- 플레이어 입력, 인벤토리, 방사형 메뉴 및 UI 상태 전환 오류 수정
- 스킬 런타임 진행 상태, 공격 지연, 요구 무기 안내 및 사용 가능 슬롯 표시 정리
- 스킬 구매 중복 차감 방지 및 동일 스킬의 마지막 선택 슬롯 이동 처리
- Addressables, 청크 리소스 및 머티리얼 인스턴스 해제 보강

## 검증
- dotnet build Assembly-CSharp.csproj --no-restore -m:1 성공
- 오류 0개