### PR TITLE
[Feat] Add data-driven NPC dialogue and combat content

### DIFF
--- a/Assets/Prefabs/Chunk/Gate.prefab
+++ b/Assets/Prefabs/Chunk/Gate.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6639366012777260794}
-  m_Layer: 0
+  m_Layer: 22
   m_Name: Gate
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -46,7 +46,7 @@ GameObject:
   - component: {fileID: 139838737368080277}
   - component: {fileID: 4978647359680318932}
   - component: {fileID: 4624484059770019111}
-  m_Layer: 20
+  m_Layer: 22
   m_Name: Pillar_Asset_Combined
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -306,7 +306,7 @@ GameObject:
   - component: {fileID: 983455075274644042}
   - component: {fileID: 7001816390275640558}
   - component: {fileID: 5052321640731082688}
-  m_Layer: 20
+  m_Layer: 22
   m_Name: Pillar_Asset_Combined (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/Manager/UI.prefab
+++ b/Assets/Prefabs/Manager/UI.prefab
@@ -1150,6 +1150,82 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &910000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910000000000000002}
+  - component: {fileID: 910000000000000003}
+  - component: {fileID: 910000000000000004}
+  m_Layer: 5
+  m_Name: DialogueBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &910000000000000002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910000000000000001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5363018641651801738}
+  m_Father: {fileID: 6194072864650156136}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.07, y: 0.045}
+  m_AnchorMax: {x: 0.79, y: 0.295}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &910000000000000003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910000000000000001}
+  m_CullTransparentMesh: 1
+--- !u!114 &910000000000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.94}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3c6bfad294e04d73a5b681c042e9f857, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &667829528087199928
 GameObject:
   m_ObjectHideFlags: 0
@@ -1210,7 +1286,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.96}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -2245,8 +2321,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3471546880584297460}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.18, y: 0.08}
+  m_AnchorMax: {x: 0.82, y: 0.92}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -2289,7 +2365,7 @@ MonoBehaviour:
   m_fontColor32:
     serializedVersion: 2
     rgba: 4287664272
-  m_fontColor: {r: 0.5660378, g: 0.5660378, b: 0.5660378, a: 1}
+  m_fontColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -2306,12 +2382,12 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 10
-  m_fontSizeMax: 24
+  m_fontSizeMin: 18
+  m_fontSizeMax: 22
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
@@ -5627,6 +5703,7 @@ GameObject:
   - component: {fileID: 2913464698811377683}
   - component: {fileID: 7519780907729111848}
   - component: {fileID: 4351463227044457808}
+  - component: {fileID: 910000000000000012}
   m_Layer: 5
   m_Name: Select2
   m_TagString: Untagged
@@ -5649,10 +5726,10 @@ RectTransform:
   - {fileID: 2549211153160516952}
   m_Father: {fileID: 6194072864650156136}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 110}
-  m_SizeDelta: {x: 200, y: 40}
+  m_AnchorMin: {x: 0.68, y: 0.445}
+  m_AnchorMax: {x: 0.96, y: 0.535}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2913464698811377683
 CanvasRenderer:
@@ -5682,8 +5759,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: b80b622d22dac6a47bf62ad4ca294ad2, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 4d7c0be3a5f14e84b697c2d153fa0869, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -5711,19 +5788,19 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 2
   m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_NormalColor: {r: 0.08, g: 0.08, b: 0.09, a: 0.72}
+    m_HighlightedColor: {r: 0.96, g: 0.94, b: 0.88, a: 0.96}
+    m_PressedColor: {r: 0.82, g: 0.78, b: 0.68, a: 1}
+    m_SelectedColor: {r: 0.96, g: 0.94, b: 0.88, a: 0.96}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
+    m_FadeDuration: 0.08
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
+    m_HighlightedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -5736,6 +5813,21 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &910000000000000012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2673858424802182120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c4a19f6d284b53a0e8c1279f35d642, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  label: {fileID: 5210390490446387375}
+  normalTextColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
+  highlightedTextColor: {r: 0.08, g: 0.08, b: 0.09, a: 1}
 --- !u!1 &2678683371635754951
 GameObject:
   m_ObjectHideFlags: 0
@@ -5795,7 +5887,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.96}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -6813,6 +6905,7 @@ GameObject:
   - component: {fileID: 8150359555271433637}
   - component: {fileID: 1772142500531464922}
   - component: {fileID: 2711055041158704145}
+  - component: {fileID: 910000000000000013}
   m_Layer: 5
   m_Name: Select3
   m_TagString: Untagged
@@ -6835,10 +6928,10 @@ RectTransform:
   - {fileID: 2633435778382371847}
   m_Father: {fileID: 6194072864650156136}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 230, y: 110}
-  m_SizeDelta: {x: 200, y: 40}
+  m_AnchorMin: {x: 0.68, y: 0.33}
+  m_AnchorMax: {x: 0.96, y: 0.42}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8150359555271433637
 CanvasRenderer:
@@ -6868,8 +6961,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: b80b622d22dac6a47bf62ad4ca294ad2, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 4d7c0be3a5f14e84b697c2d153fa0869, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -6897,19 +6990,19 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 2
   m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_NormalColor: {r: 0.08, g: 0.08, b: 0.09, a: 0.72}
+    m_HighlightedColor: {r: 0.96, g: 0.94, b: 0.88, a: 0.96}
+    m_PressedColor: {r: 0.82, g: 0.78, b: 0.68, a: 1}
+    m_SelectedColor: {r: 0.96, g: 0.94, b: 0.88, a: 0.96}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
+    m_FadeDuration: 0.08
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
+    m_HighlightedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -6922,6 +7015,21 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &910000000000000013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3305177731018677431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c4a19f6d284b53a0e8c1279f35d642, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  label: {fileID: 7853318022131353501}
+  normalTextColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
+  highlightedTextColor: {r: 0.08, g: 0.08, b: 0.09, a: 1}
 --- !u!1 &3334641328286419594
 GameObject:
   m_ObjectHideFlags: 0
@@ -6980,7 +7088,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.96}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -11417,8 +11525,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 7278799528888361366}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.18, y: 0.08}
+  m_AnchorMax: {x: 0.82, y: 0.92}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -11461,7 +11569,7 @@ MonoBehaviour:
   m_fontColor32:
     serializedVersion: 2
     rgba: 4287664272
-  m_fontColor: {r: 0.5660378, g: 0.5660378, b: 0.5660378, a: 1}
+  m_fontColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -11478,12 +11586,12 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 10
-  m_fontSizeMax: 24
+  m_fontSizeMin: 18
+  m_fontSizeMax: 22
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512
@@ -11684,6 +11792,7 @@ GameObject:
   - component: {fileID: 4884169582727531653}
   - component: {fileID: 7074911611069601462}
   - component: {fileID: 3471849088355210493}
+  - component: {fileID: 910000000000000011}
   m_Layer: 5
   m_Name: Select1
   m_TagString: Untagged
@@ -11706,10 +11815,10 @@ RectTransform:
   - {fileID: 4227328376054025622}
   m_Father: {fileID: 6194072864650156136}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -230, y: 110}
-  m_SizeDelta: {x: 200, y: 40}
+  m_AnchorMin: {x: 0.68, y: 0.56}
+  m_AnchorMax: {x: 0.96, y: 0.65}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4884169582727531653
 CanvasRenderer:
@@ -11739,8 +11848,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: b80b622d22dac6a47bf62ad4ca294ad2, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300000, guid: 4d7c0be3a5f14e84b697c2d153fa0869, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -11768,19 +11877,19 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 2
   m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_NormalColor: {r: 0.08, g: 0.08, b: 0.09, a: 0.72}
+    m_HighlightedColor: {r: 0.96, g: 0.94, b: 0.88, a: 0.96}
+    m_PressedColor: {r: 0.82, g: 0.78, b: 0.68, a: 1}
+    m_SelectedColor: {r: 0.96, g: 0.94, b: 0.88, a: 0.96}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
+    m_FadeDuration: 0.08
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
+    m_HighlightedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: 5e8d1cf4b6024f95c7a8d3e2640b197a, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -11793,6 +11902,21 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &910000000000000011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5349807347003657761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7c4a19f6d284b53a0e8c1279f35d642, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  label: {fileID: 1241965705612634934}
+  normalTextColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
+  highlightedTextColor: {r: 0.08, g: 0.08, b: 0.09, a: 1}
 --- !u!1 &5396414443873949451
 GameObject:
   m_ObjectHideFlags: 0
@@ -12550,7 +12674,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5363018641651801738}
+  - {fileID: 910000000000000002}
   - {fileID: 4652633360376877458}
   - {fileID: 7278799528888361366}
   - {fileID: 3471546880584297460}
@@ -12558,8 +12682,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 300.00012, y: -275}
-  m_SizeDelta: {x: -599.99976, y: -550}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &98884848794701642
 CanvasRenderer:
@@ -12582,14 +12706,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.03, g: 0.04, b: 0.06, a: 0.58}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: f203f165ae401fe46ada0ed50d07149c, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -14957,12 +15081,12 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6194072864650156136}
+  m_Father: {fileID: 910000000000000002}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.085, y: 0.22}
+  m_AnchorMax: {x: 0.915, y: 0.78}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -50, y: -50}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5589136532153927115
 CanvasRenderer:
@@ -15003,7 +15127,7 @@ MonoBehaviour:
   m_fontColor32:
     serializedVersion: 2
     rgba: 4289440683
-  m_fontColor: {r: 0.6698113, g: 0.6698113, b: 0.6698113, a: 1}
+  m_fontColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -15020,15 +15144,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 30
-  m_fontSizeBase: 30
+  m_fontSize: 28
+  m_fontSizeBase: 28
   m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 22
+  m_fontSizeMax: 28
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -19157,8 +19281,8 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 4652633360376877458}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.18, y: 0.08}
+  m_AnchorMax: {x: 0.82, y: 0.92}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -19201,7 +19325,7 @@ MonoBehaviour:
   m_fontColor32:
     serializedVersion: 2
     rgba: 4287664272
-  m_fontColor: {r: 0.5660378, g: 0.5660378, b: 0.5660378, a: 1}
+  m_fontColor: {r: 0.94, g: 0.94, b: 0.94, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -19218,12 +19342,12 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 1
-  m_fontSizeMin: 10
-  m_fontSizeMax: 24
+  m_fontSizeMin: 18
+  m_fontSizeMax: 22
   m_fontStyle: 0
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 512

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -46,7 +46,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ComboTime: 1
-  AttackActions: []
+  AttackActions:
+  - {fileID: 11400000, guid: b31f28d09a6c4e17af5927c834d061e2, type: 2}
+  - {fileID: 11400000, guid: c82a4e913f7b46d5b1a290ec685f3a74, type: 2}
+  - {fileID: 11400000, guid: d9473bc20e5f4816a73d19c864b20fa5, type: 2}
   ctrl: {fileID: 9106986210577024241}
   WeaponObject: {fileID: 356757173437157669}
 --- !u!1 &1327669763105304696

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks.meta
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7c1f4e28b9d43f6a5c0e2178d94b361
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_0.asset
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_0.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c5b0b0d9a0b4c7f9e2e3d1c8a6b5f02, type: 3}
+  m_Name: Attack_0
+  m_EditorClassIdentifier: 
+  EffectDelay: 0
+  ActiveDelay: 0.1
+  UseAnimationEvent: 1
+  AdditionalDamage: 0
+  KnockBackForce: 1
+  HitOffset: {x: 0, y: 0.4, z: 0.15}
+  Range: {x: 1.7, y: 1.2, z: 1.4}
+  MainVFXPrefab: {fileID: 0}
+  HitVFXPrefab: {fileID: 0}
+  MainVFXOffset: {x: 0, y: 0, z: 0}
+  MainVFXEulerAngles: {x: 0, y: 0, z: 0}
+  HitVFXOffset: {x: 0, y: 0, z: 0}
+  HitVFXEulerAngles: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_0.asset.meta
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_0.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b31f28d09a6c4e17af5927c834d061e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_1.asset
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_1.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c5b0b0d9a0b4c7f9e2e3d1c8a6b5f02, type: 3}
+  m_Name: Attack_1
+  m_EditorClassIdentifier: 
+  EffectDelay: 0
+  ActiveDelay: 0.1
+  UseAnimationEvent: 1
+  AdditionalDamage: 0
+  KnockBackForce: 1
+  HitOffset: {x: 0, y: 0.4, z: 0.15}
+  Range: {x: 1.7, y: 1.2, z: 1.4}
+  MainVFXPrefab: {fileID: 0}
+  HitVFXPrefab: {fileID: 0}
+  MainVFXOffset: {x: 0, y: 0, z: 0}
+  MainVFXEulerAngles: {x: 0, y: 0, z: 0}
+  HitVFXOffset: {x: 0, y: 0, z: 0}
+  HitVFXEulerAngles: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_1.asset.meta
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c82a4e913f7b46d5b1a290ec685f3a74
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_2.asset
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_2.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c5b0b0d9a0b4c7f9e2e3d1c8a6b5f02, type: 3}
+  m_Name: Attack_2
+  m_EditorClassIdentifier: 
+  EffectDelay: 0
+  ActiveDelay: 0.1
+  UseAnimationEvent: 1
+  AdditionalDamage: 0
+  KnockBackForce: 1
+  HitOffset: {x: 0, y: 0.4, z: 0.2}
+  Range: {x: 1.8, y: 1.2, z: 1.7}
+  MainVFXPrefab: {fileID: 0}
+  HitVFXPrefab: {fileID: 0}
+  MainVFXOffset: {x: 0, y: 0, z: 0}
+  MainVFXEulerAngles: {x: 0, y: 0, z: 0}
+  HitVFXOffset: {x: 0, y: 0, z: 0}
+  HitVFXEulerAngles: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_2.asset.meta
+++ b/Assets/Prefabs/SO_Skill/Knife/Attacks/Attack_2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d9473bc20e5f4816a73d19c864b20fa5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/NPC.meta
+++ b/Assets/Resources/NPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9852839e8c73cd4a96d9ccaac107d78
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/NPC/NPCDialogues.json
+++ b/Assets/Resources/NPC/NPCDialogues.json
@@ -1,0 +1,114 @@
+{
+  "npcs": [
+    {
+      "id": "npc_01",
+      "displayName": "드워프 대장장이",
+      "introLines": ["쇳소리만 들어도 좋은 장비인지 알 수 있지.", "자네의 전투 방식에 맞는 물건을 골라보게."],
+      "choicePrompt": "어떤 장비를 살펴보겠나?",
+      "routes": [
+        {"id":"balanced","optionText":"균형 잡힌 {itemName} - {itemPrice}$","lines":["무게 중심이 좋아 오래 싸워도 손목이 버틸 걸세."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"좋은 선택이네. 오래 쓰게."}},
+        {"id":"aggressive","optionText":"공격적인 {itemName} - {itemPrice}$","lines":["날을 얇게 세워 위력을 끌어올린 물건이지."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"적이 이 날을 두려워하게 될 걸세."}},
+        {"id":"durable","optionText":"튼튼한 {itemName} - {itemPrice}$","lines":["몇 번을 부딪쳐도 쉽게 망가지지 않을 걸세."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"험한 길에서 자네를 지켜줄 걸세."}}
+      ]
+    },
+    {
+      "id": "npc_02",
+      "displayName": "저주받은 상인",
+      "introLines": ["내 물건에는 축복과 저주가 함께 스며 있지.", "대가를 감당할 자신이 있다면 골라봐."],
+      "choicePrompt": "어느 운명에 손을 뻗겠나?",
+      "routes": [
+        {"id":"whisper","optionText":"속삭이는 {itemName} - {itemPrice}$","lines":["어둠 속에서 먼저 위험을 알려주는 물건이야."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"속삭임을 너무 오래 듣지는 마."}},
+        {"id":"blood","optionText":"피를 머금은 {itemName} - {itemPrice}$","lines":["싸움이 길어질수록 진가가 드러날 거다."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"이제 그 물건은 네 피를 기억한다."}},
+        {"id":"sealed","optionText":"봉인된 {itemName} - {itemPrice}$","lines":["봉인은 약속이지. 반드시 안전하다는 뜻은 아니야."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"봉인을 풀 시점은 네가 정해."}}
+      ]
+    },
+    {
+      "id": "npc_03",
+      "displayName": "왕실 보급관",
+      "introLines": ["왕실 창고에서 검수한 장비만 취급합니다.", "현재 임무에 적합한 보급품을 선택하십시오."],
+      "choicePrompt": "어떤 보급품을 요청하시겠습니까?",
+      "routes": [
+        {"id":"standard","optionText":"표준 지급품 {itemName} - {itemPrice}$","lines":["검증된 규격이라 어떤 전장에서도 무난합니다."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"보급 기록을 완료했습니다."}},
+        {"id":"vanguard","optionText":"선봉대 장비 {itemName} - {itemPrice}$","lines":["돌파 임무를 위해 공격 성능을 높인 장비입니다."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"선봉대의 명예를 지켜주십시오."}},
+        {"id":"guardian","optionText":"호위대 장비 {itemName} - {itemPrice}$","lines":["생존과 방어를 우선한 장기전용 장비입니다."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"무사 귀환을 기원합니다."}}
+      ]
+    },
+    {
+      "id": "npc_04",
+      "displayName": "떠돌이 수집가",
+      "introLines": ["여러 폐허를 돌며 흥미로운 물건을 모았어요.", "각 물건마다 주인의 이야기가 남아 있답니다."],
+      "choicePrompt": "어떤 이야기를 가져가시겠어요?",
+      "routes": [
+        {"id":"ruin","optionText":"폐허의 {itemName} - {itemPrice}$","lines":["무너진 성벽 아래에서도 온전했던 물건이에요."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"이제 새로운 이야기를 써주세요."}},
+        {"id":"pilgrim","optionText":"순례자의 {itemName} - {itemPrice}$","lines":["긴 여행을 견딘 흔적이 고스란히 남아 있죠."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"당신의 여정에도 도움이 되길 바라요."}},
+        {"id":"unknown","optionText":"이름 없는 {itemName} - {itemPrice}$","lines":["주인의 이름은 사라졌지만 힘은 아직 남아 있어요."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"이번에는 이름을 잃지 않게 해주세요."}}
+      ]
+    },
+    {
+      "id": "npc_05",
+      "displayName": "북부 사냥꾼",
+      "introLines": ["북부의 짐승은 한 번의 실수도 놓치지 않아.", "살아 돌아오려면 믿을 만한 장비가 필요하지."],
+      "choicePrompt": "어떤 사냥을 준비하고 있지?",
+      "routes": [
+        {"id":"tracking","optionText":"추적용 {itemName} - {itemPrice}$","lines":["발소리를 줄이고 움직임을 가볍게 해줄 거야."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"흔적을 놓치지 마."}},
+        {"id":"ambush","optionText":"매복용 {itemName} - {itemPrice}$","lines":["첫 일격에 모든 걸 끝내고 싶을 때 쓰는 물건이지."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"바람이 네 냄새를 숨겨주길."}},
+        {"id":"survival","optionText":"생존용 {itemName} - {itemPrice}$","lines":["사냥감보다 오래 버티는 자가 결국 이기는 법이야."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"반드시 살아서 돌아와."}}
+      ]
+    },
+    {
+      "id": "npc_06",
+      "displayName": "사막 대상인",
+      "introLines": ["모래바람은 값싼 장비부터 집어삼키지.", "내 물건은 긴 사막길을 건너온 진품이야."],
+      "choicePrompt": "어떤 물건에 흥미가 있나?",
+      "routes": [
+        {"id":"sun","optionText":"태양의 {itemName} - {itemPrice}$","lines":["뜨거운 열기 속에서도 힘을 잃지 않는 물건이지."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"태양이 자네의 앞길을 밝히길."}},
+        {"id":"moon","optionText":"달빛의 {itemName} - {itemPrice}$","lines":["밤의 냉기를 머금어 정신을 맑게 해준다네."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"달빛 아래에서 진가를 보게 될 거야."}},
+        {"id":"storm","optionText":"모래폭풍의 {itemName} - {itemPrice}$","lines":["거친 바람을 견딘 만큼 아주 단단하지."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"어떤 폭풍도 두렵지 않겠군."}}
+      ]
+    },
+    {
+      "id": "npc_07",
+      "displayName": "연금술사",
+      "introLines": ["장비도 재료의 조합에 따라 성질이 달라져요.", "제가 조정한 세 가지 결과물을 보여드리죠."],
+      "choicePrompt": "어떤 성질을 원하시나요?",
+      "routes": [
+        {"id":"swift","optionText":"민첩한 {itemName} - {itemPrice}$","lines":["가벼운 촉매로 반응 속도를 높였어요."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"몸이 한결 가볍게 느껴질 거예요."}},
+        {"id":"force","optionText":"강력한 {itemName} - {itemPrice}$","lines":["불안정하지만 강한 에너지를 품고 있죠."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"충격에는 조심하세요."}},
+        {"id":"stable","optionText":"안정된 {itemName} - {itemPrice}$","lines":["오래 사용할 수 있도록 반응을 안정화했어요."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"예측 가능한 힘이 가장 믿음직하죠."}}
+      ]
+    },
+    {
+      "id": "npc_08",
+      "displayName": "성소의 수호자",
+      "introLines": ["이 장비들은 오래된 성소를 지키던 이들의 유산입니다.", "마음가짐에 맞는 유산을 선택하십시오."],
+      "choicePrompt": "당신이 지키고 싶은 것은 무엇입니까?",
+      "routes": [
+        {"id":"self","optionText":"생존의 {itemName} - {itemPrice}$","lines":["자신을 지키는 것도 중요한 의무입니다."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"먼저 살아남으십시오."}},
+        {"id":"ally","optionText":"수호의 {itemName} - {itemPrice}$","lines":["동료 곁을 지키려는 의지가 깃든 장비입니다."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"그 의지를 잊지 마십시오."}},
+        {"id":"oath","optionText":"맹세의 {itemName} - {itemPrice}$","lines":["끝까지 물러서지 않는 자를 위한 유산입니다."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"맹세가 당신을 이끌 것입니다."}}
+      ]
+    },
+    {
+      "id": "npc_09",
+      "displayName": "전장 약탈자",
+      "introLines": ["전장에 주인 없는 물건이 얼마나 많은지 알아?", "쓸 만한 것만 골라왔으니 걱정은 접어둬."],
+      "choicePrompt": "어느 전리품이 마음에 들어?",
+      "routes": [
+        {"id":"officer","optionText":"장교의 {itemName} - {itemPrice}$","lines":["지휘관이 쓰던 물건이라 관리 상태가 좋아."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"이제 지휘관은 자네겠군."}},
+        {"id":"champion","optionText":"용사의 {itemName} - {itemPrice}$","lines":["마지막까지 손에서 놓지 않았던 물건이지."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"전 주인보다 오래 살아남아."}},
+        {"id":"unknown","optionText":"출처 불명의 {itemName} - {itemPrice}$","lines":["어디서 났는지는 묻지 않는 게 서로에게 좋아."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"좋아, 거래는 깔끔하게 끝났어."}}
+      ]
+    },
+    {
+      "id": "npc_10",
+      "displayName": "시간의 기록자",
+      "introLines": ["수많은 가능성 속에서 이 물건들이 당신에게 도달했습니다.", "선택하지 않은 미래는 사라지니 신중히 결정하세요."],
+      "choicePrompt": "어느 미래를 선택하시겠습니까?",
+      "routes": [
+        {"id":"past","optionText":"과거의 {itemName} - {itemPrice}$","lines":["오래된 전투의 경험이 희미하게 남아 있습니다."],"reward":{"type":"ShopItem","shopItemSlot":0,"amount":0,"successMessage":"과거의 실수를 반복하지 마세요."}},
+        {"id":"present","optionText":"현재의 {itemName} - {itemPrice}$","lines":["지금 이 순간 가장 필요한 힘을 담았습니다."],"reward":{"type":"ShopItem","shopItemSlot":1,"amount":0,"successMessage":"현재를 붙잡으세요."}},
+        {"id":"future","optionText":"미래의 {itemName} - {itemPrice}$","lines":["아직 오지 않은 승리의 가능성이 느껴집니다."],"reward":{"type":"ShopItem","shopItemSlot":2,"amount":0,"successMessage":"그 가능성을 현실로 만드세요."}}
+      ]
+    }
+  ]
+}

--- a/Assets/Resources/NPC/NPCDialogues.json.meta
+++ b/Assets/Resources/NPC/NPCDialogues.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83bb722a61cabfc4480f398712ba4287
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/AnimationState/EnemyAttack.cs
+++ b/Assets/Scripts/Enemy/AnimationState/EnemyAttack.cs
@@ -2,7 +2,9 @@ using UnityEngine;
 
 public class EnemyAttack : StateMachineBehaviour
 {
-    [SerializeField] private SkillBase skill;
+    [SerializeField]
+    [Tooltip("Optional. Leave empty when this animation state does not activate a skill.")]
+    private SkillBase skill = null;
     // OnStateEnter is called when a transition starts and the state machine starts to evaluate this state
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {

--- a/Assets/Scripts/EnumGroup.cs
+++ b/Assets/Scripts/EnumGroup.cs
@@ -29,6 +29,7 @@ public enum StatModifyType
     SkillUse = 1 << 4,
     KillEnemy = 1 << 5,
     BuyItem = 1 << 6,
+    DialogReward = 1 << 7,
 }
 
 public enum TileType

--- a/Assets/Scripts/Manager/ChunkManager/BSPNode.cs
+++ b/Assets/Scripts/Manager/ChunkManager/BSPNode.cs
@@ -76,17 +76,14 @@ public class BSPNode
             return;
         }
 
-        var roomWidthMin = Mathf.Max(1, Area.width / 2);
-        var roomHeightMin = Mathf.Max(1, Area.height / 2);
-        var roomWidthMax = Mathf.Max(roomWidthMin + 1, Area.width - margin);
-        var roomHeightMax = Mathf.Max(roomHeightMin + 1, Area.height - margin);
-
-        var roomWidth = Random.Range(roomWidthMin, roomWidthMax);
-        var roomHeight = Random.Range(roomHeightMin, roomHeightMax);
-        var roomXMax = Mathf.Max(margin + 1, Area.width - roomWidth - margin);
-        var roomYMax = Mathf.Max(margin + 1, Area.height - roomHeight - margin);
-        var roomX = Area.x + Random.Range(margin, roomXMax);
-        var roomY = Area.y + Random.Range(margin, roomYMax);
+        var availableWidth = Area.width - margin * 2;
+        var availableHeight = Area.height - margin * 2;
+        var roomWidthMin = Mathf.Max(1, Mathf.CeilToInt(availableWidth * 0.8f));
+        var roomHeightMin = Mathf.Max(1, Mathf.CeilToInt(availableHeight * 0.8f));
+        var roomWidth = Random.Range(roomWidthMin, availableWidth + 1);
+        var roomHeight = Random.Range(roomHeightMin, availableHeight + 1);
+        var roomX = Area.x + Random.Range(margin, Area.width - roomWidth - margin + 1);
+        var roomY = Area.y + Random.Range(margin, Area.height - roomHeight - margin + 1);
 
         room = new RectInt(roomX, roomY, roomWidth, roomHeight);
     }

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -39,7 +39,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
         Vector2Int.right
     };
 
-    [SerializeField] private NavMeshSurface m_surface;
+    [SerializeField] private NavMeshSurface m_surface = null;
 
     private IEnumerator Start()
     {

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -73,9 +73,9 @@ public class MapGenerator : MonoBehaviour
 
         foreach (var room in root.GetRooms())
         {
-            for (var x = room.xMin + 1; x < room.xMax - 1; x++)
+            for (var x = room.xMin; x < room.xMax; x++)
             {
-                for (var y = room.yMin + 1; y < room.yMax - 1; y++)
+                for (var y = room.yMin; y < room.yMax; y++)
                 {
                     if (IsInside(mapData, x, y))
                     {
@@ -143,9 +143,9 @@ public class MapGenerator : MonoBehaviour
             }
         }
 
-        for (var x = 0; x < width; x++)
+        for (var x = 0; x <= width; x++)
         {
-            for (var y = 0; y < height; y++)
+            for (var y = -1; y < height; y++)
             {
                 if (CreatePillar(mapData, x, y, ToWorldPosition(bounds, x, y, blockSize), parent))
                 {
@@ -175,16 +175,15 @@ public class MapGenerator : MonoBehaviour
 
     private bool CreatePillar(TileType[,] map, int x, int y, Vector3 wallPos, Transform parent)
     {
-        if (x < 1 || y > map.GetLength(1) - 2) return false;
-
-        var left = map[x - 1, y] == TileType.Wall;
-        var up = map[x, y + 1] == TileType.Wall;
-        var leftUp = map[x - 1, y + 1] == TileType.Wall;
-        var exceptions = (left && up && leftUp) || (!left && up && !leftUp) || (left && !up && !leftUp);
-        var exceptions2 = !left && !up && leftUp;
-
-        var shouldCreate = exceptions ^ (map[x, y] == TileType.Wall);
-        shouldCreate |= exceptions2;
+        var current = IsWall(map, x, y);
+        var left = IsWall(map, x - 1, y);
+        var up = IsWall(map, x, y + 1);
+        var leftUp = IsWall(map, x - 1, y + 1);
+        var wallCount = (current ? 1 : 0)
+                        + (left ? 1 : 0)
+                        + (up ? 1 : 0)
+                        + (leftUp ? 1 : 0);
+        var shouldCreate = wallCount == 1 || wallCount == 3;
 
         if (shouldCreate && m_tiles.TryGetValue(TileType.Pillar, out var pillar))
         {
@@ -195,6 +194,11 @@ public class MapGenerator : MonoBehaviour
         }
 
         return false;
+    }
+
+    private bool IsWall(TileType[,] map, int x, int y)
+    {
+        return IsInside(map, x, y) && map[x, y] == TileType.Wall;
     }
 
     private void ConnectRooms(BSPNode node, TileType[,] mapData)
@@ -316,8 +320,9 @@ public class MapGenerator : MonoBehaviour
         var current = start;
         var forwardStep = new Vector3(dir.x * blockSize.x, 0f, dir.y * blockSize.z);
         var sideStep = dir.x == 0 ? new Vector3(Mathf.Sign(end.x - start.x) * blockSize.x, 0f, 0f) : new Vector3(0f, 0f, Mathf.Sign(end.z - start.z) * blockSize.z);
+        var carvedCells = new HashSet<Vector3>();
 
-        CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+        CarveTunnelCell(chunk, neighborChunk, current, blockSize, carvedCells);
 
         if (dir.x == 0)
         {
@@ -329,7 +334,7 @@ public class MapGenerator : MonoBehaviour
                     current.z = end.z;
                 }
 
-                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize, carvedCells);
             }
 
             while (Mathf.Approximately(current.x, end.x) == false)
@@ -340,7 +345,7 @@ public class MapGenerator : MonoBehaviour
                     current.x = end.x;
                 }
 
-                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize, carvedCells);
             }
         }
         else
@@ -353,7 +358,7 @@ public class MapGenerator : MonoBehaviour
                     current.x = end.x;
                 }
 
-                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize, carvedCells);
             }
 
             while (Mathf.Approximately(current.z, end.z) == false)
@@ -364,12 +369,19 @@ public class MapGenerator : MonoBehaviour
                     current.z = end.z;
                 }
 
-                CarveTunnelCell(chunk, neighborChunk, current, blockSize);
+                CarveTunnelCell(chunk, neighborChunk, current, blockSize, carvedCells);
             }
         }
+
+        RebuildTunnelPillars(chunk, neighborChunk, carvedCells, blockSize);
     }
 
-    private void CarveTunnelCell(Chunk chunk, Chunk neighborChunk, Vector3 pos, Vector3Int blockSize)
+    private void CarveTunnelCell(
+        Chunk chunk,
+        Chunk neighborChunk,
+        Vector3 pos,
+        Vector3Int blockSize,
+        ISet<Vector3> carvedCells)
     {
         var owner = ContainsWorldPosition(chunk, pos, blockSize) ? chunk : neighborChunk;
         RemoveBlockingTiles(pos, blockSize);
@@ -383,6 +395,8 @@ public class MapGenerator : MonoBehaviour
         {
             owner.floorPosData.Add(pos);
         }
+
+        carvedCells.Add(pos);
     }
 
     private bool HasFloorData(List<Vector3> floors, Vector3 pos)
@@ -420,12 +434,10 @@ public class MapGenerator : MonoBehaviour
     private void RemoveBlockingTiles(Vector3 pos, Vector3Int blockSize)
     {
         var wallLayer = LayerMask.NameToLayer(TileType.Wall.ToString());
-        var pillarLayer = LayerMask.NameToLayer(TileType.Pillar.ToString());
         var gateLayer = LayerMask.NameToLayer(TileType.Gate.ToString());
         var mask = 0;
 
         if (wallLayer >= 0) mask |= 1 << wallLayer;
-        if (pillarLayer >= 0) mask |= 1 << pillarLayer;
         if (gateLayer >= 0) mask |= 1 << gateLayer;
         if (mask == 0) mask = Physics.DefaultRaycastLayers;
 
@@ -433,7 +445,69 @@ public class MapGenerator : MonoBehaviour
         var hitCount = Physics.OverlapBoxNonAlloc(pos + Vector3.up * 0.5f, halfExtents, m_overlapBuffer, Quaternion.identity, mask);
         for (var i = 0; i < hitCount; i++)
         {
-            Destroy(m_overlapBuffer[i].gameObject);
+            var blockingObject = m_overlapBuffer[i].gameObject;
+            blockingObject.SetActive(false);
+            Destroy(blockingObject);
+        }
+    }
+
+    private void RebuildTunnelPillars(
+        Chunk chunk,
+        Chunk neighborChunk,
+        IEnumerable<Vector3> carvedCells,
+        Vector3Int blockSize)
+    {
+        if (m_tiles.TryGetValue(TileType.Pillar, out var pillar) == false) return;
+
+        var halfX = blockSize.x * 0.5f;
+        var halfZ = blockSize.z * 0.5f;
+        var vertices = new HashSet<Vector3>();
+        foreach (var cell in carvedCells)
+        {
+            vertices.Add(new Vector3(cell.x - halfX, 0f, cell.z - halfZ));
+            vertices.Add(new Vector3(cell.x - halfX, 0f, cell.z + halfZ));
+            vertices.Add(new Vector3(cell.x + halfX, 0f, cell.z - halfZ));
+            vertices.Add(new Vector3(cell.x + halfX, 0f, cell.z + halfZ));
+        }
+
+        Physics.SyncTransforms();
+        foreach (var vertex in vertices)
+        {
+            RemovePillarAt(vertex);
+
+            var wallCount = 0;
+            if (HasTileAt(vertex + new Vector3(-halfX, 0f, -halfZ), TileType.Wall, blockSize)) wallCount++;
+            if (HasTileAt(vertex + new Vector3(-halfX, 0f, halfZ), TileType.Wall, blockSize)) wallCount++;
+            if (HasTileAt(vertex + new Vector3(halfX, 0f, -halfZ), TileType.Wall, blockSize)) wallCount++;
+            if (HasTileAt(vertex + new Vector3(halfX, 0f, halfZ), TileType.Wall, blockSize)) wallCount++;
+
+            if (wallCount != 1 && wallCount != 3) continue;
+
+            var owner = ContainsWorldPosition(chunk, vertex, blockSize)
+                ? chunk
+                : neighborChunk;
+            var obj = pillar.pool.GetObject();
+            obj.SetParent(owner.ChunkObject.transform, true);
+            obj.position = vertex + Vector3.up * pillar.offset.y;
+        }
+    }
+
+    private void RemovePillarAt(Vector3 vertex)
+    {
+        var pillarLayer = LayerMask.NameToLayer(TileType.Pillar.ToString());
+        if (pillarLayer < 0) return;
+
+        var hitCount = Physics.OverlapBoxNonAlloc(
+            vertex + Vector3.up * 1.5f,
+            new Vector3(0.6f, 2f, 0.6f),
+            m_overlapBuffer,
+            Quaternion.identity,
+            1 << pillarLayer);
+        for (var i = 0; i < hitCount; i++)
+        {
+            var pillarObject = m_overlapBuffer[i].gameObject;
+            pillarObject.SetActive(false);
+            Destroy(pillarObject);
         }
     }
 
@@ -530,7 +604,8 @@ public class MapGenerator : MonoBehaviour
             Destroy(hitInfo.collider.gameObject);
         }
 
-        CreateTunnelGates(startPos, rayDir, tunnelLength, parent);
+        // Gate generation is temporarily disabled.
+        // CreateTunnelGates(startPos, rayDir, tunnelLength, parent);
     }
 
     private void CreateTunnelFloor(Vector3 pos, Transform parent)

--- a/Assets/Scripts/NPC/DialogueChoiceHover.cs
+++ b/Assets/Scripts/NPC/DialogueChoiceHover.cs
@@ -1,0 +1,63 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class DialogueChoiceHover : MonoBehaviour,
+    IPointerEnterHandler,
+    IPointerExitHandler,
+    ISelectHandler,
+    IDeselectHandler
+{
+    [SerializeField] private TMP_Text label;
+    [SerializeField] private Color normalTextColor = new(0.94f, 0.94f, 0.94f, 1f);
+    [SerializeField] private Color highlightedTextColor = new(0.08f, 0.08f, 0.09f, 1f);
+
+    private bool m_isHovered;
+    private bool m_isSelected;
+
+    private void OnEnable()
+    {
+        Refresh();
+    }
+
+    private void OnDisable()
+    {
+        m_isHovered = false;
+        m_isSelected = false;
+        Refresh();
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        m_isHovered = true;
+        Refresh();
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        m_isHovered = false;
+        Refresh();
+    }
+
+    public void OnSelect(BaseEventData eventData)
+    {
+        m_isSelected = true;
+        Refresh();
+    }
+
+    public void OnDeselect(BaseEventData eventData)
+    {
+        m_isSelected = false;
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        if (label != null)
+        {
+            label.color = m_isHovered || m_isSelected
+                ? highlightedTextColor
+                : normalTextColor;
+        }
+    }
+}

--- a/Assets/Scripts/NPC/DialogueChoiceHover.cs.meta
+++ b/Assets/Scripts/NPC/DialogueChoiceHover.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e7c4a19f6d284b53a0e8c1279f35d642

--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -1,12 +1,17 @@
 using System.Collections.Generic;
+using System;
 using UnityEngine;
 using UnityEngine.AI;
 
 public class NPCBase : MonoBehaviour
 {
     public NPCType Type;
+    [Tooltip("Empty values use npc_01, npc_02, ... based on NPCType.")]
+    public string DialogueId;
     public Vector3 SpawnOffset = Vector3.up;
     public float ChunkRefreshDelay = 2f;
+
+    [Header("Legacy fallback")]
     public List<string> DialogTexts;
     public NavMeshAgent NavAgent;
     [Header("Max Count is 3")]
@@ -14,24 +19,30 @@ public class NPCBase : MonoBehaviour
 
     private bool m_isTouch;
     private bool m_isInteract;
-    private bool m_canSelectItem;
-    private int m_textLine;
+    private bool m_rewardClaimed;
+    private bool m_waitingForChoice;
+    private int m_introLine;
+    private int m_routeLine;
     private InGameLoop gameLoop;
     private ChunkManager m_chunkManager;
     private PlayerController m_player;
     private NPCDialog m_dialog;
+    private NPCDialogueEntry m_dialogue;
+    private NPCDialogueRoute m_selectedRoute;
     private readonly HashSet<Collider> m_playerColliders = new();
 
     private void Awake()
     {
         if (NavAgent != null) NavAgent.enabled = false;
     }
+
     private void OnEnable()
     {
         m_isTouch = false;
         m_player = null;
         m_playerColliders.Clear();
-        m_canSelectItem = true;
+        m_rewardClaimed = false;
+        m_waitingForChoice = false;
         m_isInteract = false;
         if (SelectItems != null && SelectItems.Count > 3)
         {
@@ -44,7 +55,8 @@ public class NPCBase : MonoBehaviour
             gameLoop.StageLevel.OnValueChanged += DestroyThisNPC;
             m_chunkManager = gameLoop.ChunkManager;
 
-            if (gameLoop.UI != null && gameLoop.UI.UIElements.TryGetValue(UIState.Dialog, out var element))
+            if (gameLoop.UI != null &&
+                gameLoop.UI.UIElements.TryGetValue(UIState.Dialog, out var element))
             {
                 m_dialog = element as NPCDialog;
             }
@@ -81,14 +93,14 @@ public class NPCBase : MonoBehaviour
         var interactAction = m_player?.input?.currentActionMap?.FindAction("Interact");
         if (interactAction != null && interactAction.triggered)
         {
-            // 플레이어 향해 회전
             var target = m_player.transform.position;
             target.y = transform.position.y;
-            transform.LookAt(target, Vector3.up);   
+            transform.LookAt(target, Vector3.up);
             if (m_isInteract) Interact();
             else StartInteract();
         }
     }
+
     private void OnTriggerExit(Collider other)
     {
         if (m_playerColliders.Remove(other) == false) return;
@@ -100,83 +112,421 @@ public class NPCBase : MonoBehaviour
 
     public void StartInteract()
     {
-        // Interact만 동작하도록 설정
-        if (m_dialog == null || DialogTexts.Count < 1)
+        if (ResolveDialog() == false)
         {
             EndInteract();
+            return;
         }
-        else
+
+        m_dialogue = NPCDialogueDatabase.Get(GetDialogueId()) ??
+                     NPCDialogueDatabase.CreateLegacy(
+                         DialogTexts,
+                         SelectItems?.Count ?? 0);
+        if (m_dialogue == null)
         {
-            m_textLine = 0;
-            // Dialog UI 제작후, 컨트롤러에 등록하면, 해당 Dialog UI를 활성화
-
-            gameLoop.UI.ChangeState(UIState.Dialog);
-            m_dialog.Init(this);
-
-            m_isInteract = true;
-
-            Interact();
+            EndInteract();
+            return;
         }
+
+        gameLoop.UI.ChangeState(UIState.Dialog);
+        m_dialog.Init(this);
+
+        m_introLine = 0;
+        m_routeLine = 0;
+        m_selectedRoute = null;
+        m_waitingForChoice = false;
+        m_isInteract = true;
+        Interact();
     }
 
     public virtual void Interact()
     {
-        if (m_dialog == null) return;
+        if (m_dialog == null || m_dialogue == null || m_waitingForChoice) return;
 
-        // DIalog UI에서 ContinueDialog 메서드를 호출하며 순서대로 메세지 띄우기
-        if (m_textLine < DialogTexts.Count -1)
+        if (m_selectedRoute == null)
         {
-            m_dialog.ContinueDialog(DialogTexts[m_textLine],false);
-        }
-        else if (m_textLine == DialogTexts.Count -1)
-        {
-            if (m_canSelectItem)
+            if (m_introLine < (m_dialogue.introLines?.Length ?? 0))
             {
-                m_dialog.SelectDialog(DialogTexts[m_textLine], SelectItems);
+                m_dialog.ShowLine(m_dialogue.introLines[m_introLine++]);
+                return;
             }
-            else
-                m_dialog.ContinueDialog(DialogTexts[m_textLine], false);
-        }
-        else
-        {
-            if (m_canSelectItem == false)
-                m_dialog.ContinueDialog("", true);
+
+            m_waitingForChoice = true;
+            m_dialog.ShowRoutes(
+                m_dialogue.choicePrompt,
+                m_dialogue.routes,
+                SelectItems);
+            return;
         }
 
-        m_textLine++;
+        if (m_routeLine < (m_selectedRoute.lines?.Length ?? 0))
+        {
+            m_dialog.ShowLine(m_selectedRoute.lines[m_routeLine++]);
+            return;
+        }
+
+        CompleteSelectedRoute();
+    }
+
+    public void SelectRoute(int routeIndex)
+    {
+        if (m_waitingForChoice == false ||
+            m_dialogue?.routes == null ||
+            routeIndex < 0 ||
+            routeIndex >= m_dialogue.routes.Length)
+        {
+            return;
+        }
+
+        m_selectedRoute = m_dialogue.routes[routeIndex];
+        m_routeLine = 0;
+        m_waitingForChoice = false;
+        m_dialog.HideChoices();
+        Interact();
     }
 
     public virtual void EndInteract()
     {
-        if (m_dialog == null) return;
-        if (m_canSelectItem)
-        {
-            m_canSelectItem = false;
-        }
         m_isInteract = false;
-        m_dialog = null;
+        m_waitingForChoice = false;
+        m_selectedRoute = null;
+        m_dialogue = null;
     }
+
+    private void CompleteSelectedRoute()
+    {
+        if (m_selectedRoute == null) return;
+
+        if (m_rewardClaimed)
+        {
+            m_dialog.ShowCompletion("이 NPC와의 거래는 이미 마쳤습니다.");
+            return;
+        }
+
+        var success = TryApplyReward(m_selectedRoute.reward, out var message);
+        if (success) m_rewardClaimed = true;
+        m_dialog.ShowCompletion(message);
+    }
+
+    private bool TryApplyReward(NPCDialogueReward reward, out string message)
+    {
+        if (reward == null ||
+            string.IsNullOrWhiteSpace(reward.type) ||
+            string.Equals(reward.type, "None", System.StringComparison.OrdinalIgnoreCase))
+        {
+            message = reward?.successMessage ?? "이야기를 들어줘서 고맙습니다.";
+            return true;
+        }
+
+        var player = gameLoop?.Player;
+        if (player?.model == null)
+        {
+            message = "보상을 지급할 플레이어를 찾을 수 없습니다.";
+            return false;
+        }
+
+        if (string.Equals(
+                reward.type,
+                "ShopItem",
+                System.StringComparison.OrdinalIgnoreCase))
+        {
+            return TryPurchaseShopItem(reward, player, out message);
+        }
+
+        if (string.Equals(
+                reward.type,
+                "Money",
+                System.StringComparison.OrdinalIgnoreCase))
+        {
+            player.model.Money.AddModifier(
+                new StatModifier(Mathf.Max(0f, reward.amount)),
+                StatModifyType.DialogReward);
+            message = GetSuccessMessage(reward, $"{reward.amount:F0}$를 받았습니다.");
+            return true;
+        }
+
+        if (string.Equals(
+                reward.type,
+                "RestoreHealth",
+                System.StringComparison.OrdinalIgnoreCase))
+        {
+            RestoreStat(player.model.Health, reward.amount, StatModifyType.Damage);
+            message = GetSuccessMessage(reward, "체력을 회복했습니다.");
+            return true;
+        }
+
+        if (string.Equals(
+                reward.type,
+                "RestoreMana",
+                System.StringComparison.OrdinalIgnoreCase))
+        {
+            RestoreStat(player.model.Mana, reward.amount, StatModifyType.SkillUse);
+            message = GetSuccessMessage(reward, "마나를 회복했습니다.");
+            return true;
+        }
+
+        message = $"지원하지 않는 NPC 보상 타입입니다: {reward.type}";
+        return false;
+    }
+
+    private bool TryPurchaseShopItem(
+        NPCDialogueReward reward,
+        PlayerController player,
+        out string message)
+    {
+        var item = NPCDialogueDatabase.GetShopItem(SelectItems, reward.shopItemSlot);
+        if (item == null)
+        {
+            message = "선택한 장비는 현재 품절입니다.";
+            return false;
+        }
+
+        if (player.model.Money.TotalValue < item.Price)
+        {
+            message = "소지금이 부족합니다.";
+            return false;
+        }
+
+        if (gameLoop.UI.UIElements.TryGetValue(UIState.Inventory, out var element) == false ||
+            element is not InventorySystem inventory ||
+            inventory.HasEmptySlot() == false)
+        {
+            message = "인벤토리가 가득 찼습니다.";
+            return false;
+        }
+
+        var purchasedItem = Instantiate(item);
+        if (inventory.TryAddItem(purchasedItem) == false)
+        {
+            Destroy(purchasedItem);
+            message = "장비를 인벤토리에 추가하지 못했습니다.";
+            return false;
+        }
+
+        player.model.Money.AddModifier(
+            new StatModifier(-item.Price),
+            StatModifyType.BuyItem);
+        message = GetSuccessMessage(
+            reward,
+            $"{item.Name}을(를) 구매했습니다.");
+        return true;
+    }
+
+    private static void RestoreStat(
+        Stat stat,
+        float requestedAmount,
+        StatModifyType modifierType)
+    {
+        if (stat == null) return;
+        var amount = Mathf.Min(
+            Mathf.Max(0f, requestedAmount),
+            Mathf.Max(0f, stat.maxValue - stat.TotalValue));
+        if (amount > 0f)
+        {
+            stat.AddModifier(new StatModifier(amount), modifierType);
+        }
+    }
+
+    private static string GetSuccessMessage(
+        NPCDialogueReward reward,
+        string fallback)
+    {
+        return string.IsNullOrWhiteSpace(reward.successMessage)
+            ? fallback
+            : reward.successMessage;
+    }
+
+    private string GetDialogueId()
+    {
+        return string.IsNullOrWhiteSpace(DialogueId)
+            ? $"npc_{(int)Type:00}"
+            : DialogueId.Trim();
+    }
+
+    private bool ResolveDialog()
+    {
+        if (m_dialog != null) return true;
+
+        gameLoop ??= InGameLoop.Instance;
+        if (gameLoop?.UI == null) return false;
+
+        if (gameLoop.UI.UIElements.TryGetValue(UIState.Dialog, out var element))
+        {
+            m_dialog = element as NPCDialog;
+        }
+
+        return m_dialog != null;
+    }
+
     public void ChunkRefresh()
     {
         if (m_chunkManager == null) return;
 
         var chunk = m_chunkManager.GetChunk(transform.position);
-        // 청크와 함께 관리
         if (chunk != null)
         {
             transform.parent = chunk.ChunkObject.transform;
         }
-        // 정해진 청크 위치에 없는 적은 다시 반환
         else
         {
             DestroyThisNPC(-1);
         }
     }
+
     private void DestroyThisNPC(int stageLevel)
     {
         if (InGameLoop.Instance != null)
         {
             InGameLoop.Instance.NPCSpawner.DestroyNPC(this);
+        }
+    }
+}
+
+[Serializable]
+public class NPCDialogueCollection
+{
+    public NPCDialogueEntry[] npcs;
+}
+
+[Serializable]
+public class NPCDialogueEntry
+{
+    public string id;
+    public string displayName;
+    public string[] introLines;
+    public string choicePrompt;
+    public NPCDialogueRoute[] routes;
+}
+
+[Serializable]
+public class NPCDialogueRoute
+{
+    public string id;
+    public string optionText;
+    public string[] lines;
+    public NPCDialogueReward reward;
+}
+
+[Serializable]
+public class NPCDialogueReward
+{
+    public string type;
+    public int shopItemSlot = -1;
+    public float amount;
+    public string successMessage;
+}
+
+public static class NPCDialogueDatabase
+{
+    private const string ResourcePath = "NPC/NPCDialogues";
+    private static Dictionary<string, NPCDialogueEntry> s_dialogues;
+
+    public static NPCDialogueEntry Get(string id)
+    {
+        EnsureLoaded();
+        if (string.IsNullOrWhiteSpace(id)) return null;
+
+        s_dialogues.TryGetValue(id, out var dialogue);
+        return dialogue;
+    }
+
+    public static string FormatOption(
+        NPCDialogueRoute route,
+        IReadOnlyList<InventoryItem> shopItems)
+    {
+        if (route == null) return string.Empty;
+
+        var text = route.optionText ?? string.Empty;
+        var reward = route.reward;
+        if (reward == null ||
+            string.Equals(reward.type, "ShopItem", StringComparison.OrdinalIgnoreCase) == false)
+        {
+            return text;
+        }
+
+        var item = GetShopItem(shopItems, reward.shopItemSlot);
+        return item != null
+            ? $"{item.Name}\n{item.Price:N0} G"
+            : "품절";
+    }
+
+    public static InventoryItem GetShopItem(
+        IReadOnlyList<InventoryItem> shopItems,
+        int slot)
+    {
+        return shopItems != null && slot >= 0 && slot < shopItems.Count
+            ? shopItems[slot]
+            : null;
+    }
+
+    public static NPCDialogueEntry CreateLegacy(
+        IReadOnlyList<string> lines,
+        int shopItemCount)
+    {
+        var introCount = Mathf.Max(0, (lines?.Count ?? 0) - 1);
+        var introLines = new string[introCount];
+        for (var index = 0; index < introCount; index++)
+        {
+            introLines[index] = lines[index];
+        }
+
+        var routeCount = Mathf.Clamp(shopItemCount, 0, 3);
+        var routes = new NPCDialogueRoute[routeCount];
+        for (var index = 0; index < routeCount; index++)
+        {
+            routes[index] = new NPCDialogueRoute
+            {
+                id = $"legacy_shop_{index}",
+                optionText = "{itemName}",
+                lines = Array.Empty<string>(),
+                reward = new NPCDialogueReward
+                {
+                    type = "ShopItem",
+                    shopItemSlot = index,
+                    successMessage = "거래 고맙네. 행운을 빌지, 모험가."
+                }
+            };
+        }
+
+        return new NPCDialogueEntry
+        {
+            id = "legacy",
+            displayName = "Merchant",
+            introLines = introLines,
+            choicePrompt = lines != null && lines.Count > 0
+                ? lines[lines.Count - 1]
+                : "필요한 장비를 골라보게.",
+            routes = routes
+        };
+    }
+
+    private static void EnsureLoaded()
+    {
+        if (s_dialogues != null) return;
+
+        s_dialogues = new Dictionary<string, NPCDialogueEntry>(
+            StringComparer.OrdinalIgnoreCase);
+        var asset = Resources.Load<TextAsset>(ResourcePath);
+        if (asset == null)
+        {
+            Debug.LogError($"NPC dialogue JSON was not found at Resources/{ResourcePath}.json.");
+            return;
+        }
+
+        var collection = JsonUtility.FromJson<NPCDialogueCollection>(asset.text);
+        if (collection?.npcs == null)
+        {
+            Debug.LogError("NPC dialogue JSON is empty or invalid.");
+            return;
+        }
+
+        foreach (var dialogue in collection.npcs)
+        {
+            if (dialogue == null || string.IsNullOrWhiteSpace(dialogue.id)) continue;
+            if (s_dialogues.TryAdd(dialogue.id, dialogue) == false)
+            {
+                Debug.LogWarning($"Duplicate NPC dialogue id ignored: {dialogue.id}");
+            }
         }
     }
 }

--- a/Assets/Scripts/NPC/NPCDialog.cs
+++ b/Assets/Scripts/NPC/NPCDialog.cs
@@ -1,6 +1,6 @@
-using DG.Tweening;
 using System;
 using System.Collections.Generic;
+using DG.Tweening;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,10 +14,12 @@ public class NPCDialog : UIElementBase
         public TextMeshProUGUI textMesh;
         [HideInInspector] public InventoryItem selctItem;
     }
+
     [SerializeField] private TextMeshProUGUI mainTextMesh;
     [SerializeField] private List<ButtonContent> select;
 
     private NPCBase m_interactNPC;
+    private Sequence m_closeSequence;
 
     private void OnEnable()
     {
@@ -27,90 +29,89 @@ public class NPCDialog : UIElementBase
         {
             select.RemoveRange(3, select.Count - 3);
         }
+        SetChoicesActive(false);
     }
 
     protected override void OnDisable()
     {
-        base.OnDisable();
-        foreach (var item in select)
+        m_closeSequence?.Kill();
+        if (select != null)
         {
-            item.btn.onClick.RemoveAllListeners();
+            foreach (var item in select)
+            {
+                item?.btn?.onClick.RemoveAllListeners();
+            }
         }
+        base.OnDisable();
     }
 
     public void Init(NPCBase npc)
     {
         m_interactNPC = npc;
+        if (select == null) return;
+
+        for (var index = 0; index < select.Count; index++)
+        {
+            var routeIndex = index;
+            select[index].btn.onClick.RemoveAllListeners();
+            select[index].btn.onClick.AddListener(
+                () => m_interactNPC?.SelectRoute(routeIndex));
+        }
+    }
+
+    public void ShowLine(string message)
+    {
+        if (mainTextMesh != null) mainTextMesh.text = message ?? string.Empty;
+        SetChoicesActive(false);
+    }
+
+    public void ShowRoutes(
+        string message,
+        IReadOnlyList<NPCDialogueRoute> routes,
+        IReadOnlyList<InventoryItem> shopItems)
+    {
+        if (mainTextMesh != null) mainTextMesh.text = message ?? string.Empty;
+        if (select == null) return;
+
+        for (var index = 0; index < select.Count; index++)
+        {
+            var hasRoute = routes != null &&
+                           index < routes.Count &&
+                           routes[index] != null;
+            select[index].btn.gameObject.SetActive(hasRoute);
+            if (hasRoute && select[index].textMesh != null)
+            {
+                select[index].textMesh.text =
+                    NPCDialogueDatabase.FormatOption(routes[index], shopItems);
+            }
+        }
+    }
+
+    public void ShowCompletion(string message)
+    {
+        ShowLine(message);
+        m_closeSequence?.Kill();
+        m_closeSequence = DOTween.Sequence()
+            .SetUpdate(true)
+            .AppendInterval(2f)
+            .OnComplete(() =>
+            {
+                m_interactNPC?.EndInteract();
+                Controller.ChangeState(UIState.None);
+            });
+    }
+
+    public void HideChoices()
+    {
+        SetChoicesActive(false);
+    }
+
+    private void SetChoicesActive(bool isActive)
+    {
+        if (select == null) return;
         foreach (var item in select)
         {
-            item.btn.onClick.AddListener(() => EndInteract(item.selctItem));
+            if (item?.btn != null) item.btn.gameObject.SetActive(isActive);
         }
-    }
-
-    public void ContinueDialog(string message,bool isEnd)
-    {
-        mainTextMesh.text = message;
-        if(isEnd) EndInteract(null);
-    }
-
-    public void SelectDialog(string message, List<InventoryItem> selectItems)
-    {
-        mainTextMesh.text = message;
-        for (int i = 0; i < selectItems.Count; i++)
-        {
-            select[i].textMesh.text = $"{selectItems[i].Name} - {selectItems[i].Price}$";
-            select[i].selctItem = selectItems[i];
-            select[i].btn.gameObject.SetActive(true);
-        }
-    }
-
-    private void EndInteract(InventoryItem selectItem)
-    {
-        if (selectItem != null)
-        {
-            var player = Controller.Player;
-            if (player == null || player.model == null)
-            {
-                mainTextMesh.text = "거래를 진행할 수 없습니다.";
-            }
-            else if (player.model.Stats[StatType.Money].TotalValue < selectItem.Price)
-            {
-                mainTextMesh.text = "빈손으로 또 왔군. 이번에도 거래는 없어.";
-            }
-            else if (Controller.UIElements.TryGetValue(UIState.Inventory, out var element) == false ||
-                     element is not InventorySystem inventory ||
-                     inventory.HasEmptySlot() == false)
-            {
-                mainTextMesh.text = "소지품이 가득 찼군. 자리를 비우고 다시 오게.";
-            }
-            else
-            {
-                var purchasedItem = Instantiate(selectItem);
-                if (inventory.TryAddItem(purchasedItem))
-                {
-                    player.model.Stats[StatType.Money].AddModifier(
-                        new StatModifier(-selectItem.Price),
-                        StatModifyType.BuyItem);
-                    mainTextMesh.text = "거래는 끝났소. 행운을 빌지, 모험가.";
-                }
-                else
-                {
-                    Destroy(purchasedItem);
-                    mainTextMesh.text = "거래를 완료하지 못했네. 다시 시도해 주게.";
-                }
-            }
-        }
-        Sequence seq = DOTween.Sequence();
-        seq.SetUpdate(true) // Time.timeScale 무시
-           .AppendInterval(2f)
-           .OnComplete(() =>
-           {
-               m_interactNPC.EndInteract();
-               foreach (var item in select)
-               {
-                   item.btn.gameObject.SetActive(false);
-               }
-               Controller.ChangeState(UIState.None);
-           });
     }
 }

--- a/Assets/Scripts/NPC/NPCSpawner.cs
+++ b/Assets/Scripts/NPC/NPCSpawner.cs
@@ -77,6 +77,9 @@ public class NPCSpawner : MonoBehaviour
 
     private void SetItem(NPCBase npc)
     {
+        npc.SelectItems ??= new List<InventoryItem>();
+        npc.SelectItems.Clear();
+
         var maxLevel = m_inGameLoop.ExitStage;
         var curLevel = m_inGameLoop.StageLevel.Value;
         var pickList = m_pickList.OrderBy(_ => Random.value).Take(3).ToList();
@@ -96,8 +99,6 @@ public class NPCSpawner : MonoBehaviour
                 startIdx = Mathf.Clamp(startIdx, 0, list.Count - 1);
                 endExclusive = Mathf.Clamp(endExclusive, startIdx + 1, list.Count);
                 var pickIdx = Random.Range(startIdx, endExclusive);
-                if (npc.SelectItems == null) npc.SelectItems = new();
-
                 npc.SelectItems.Add(list[pickIdx]);
             }
         }


### PR DESCRIPTION
## 작업 내용
- Knife 기본 공격을 AttackAction SO로 구성하고 Player 프리팹에 연결
- NPC 대화를 JSON 기반 10개 NPC, 각 3개 선택 루트 구조로 전환
- 대화 선택에 따른 장비 구매, 재화, 체력 및 마나 보상 처리 추가
- 대화 패널, 선택지 배치, 텍스트 스타일과 호버 피드백 개선
- 청크 방 크기와 통로 기둥 재구성 로직을 안정화하고 게이트 생성을 임시 차단
- 선택적 Inspector 참조 의도를 명확히 해 경고를 정리

## 검증
- NPC JSON 파싱 확인: NPC 10명, 각 선택 루트 3개
- git diff 및 커밋별 기능 범위 확인
- dotnet build 시도
- Unity 패키지 테스트 및 Editor 생성 프로젝트의 기존 TestTools/MemoryProfiler 참조 오류로 전체 빌드 완료 불가