### PR TITLE
[Feat] Restrict NPC weapon progression

### DIFF
--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -288,8 +288,20 @@ public class NPCBase : MonoBehaviour
         }
 
         if (gameLoop.UI.UIElements.TryGetValue(UIState.Inventory, out var element) == false ||
-            element is not InventorySystem inventory ||
-            inventory.HasEmptySlot() == false)
+            element is not InventorySystem inventory)
+        {
+            message = "인벤토리를 찾을 수 없습니다.";
+            return false;
+        }
+
+        if (inventory.CanPurchaseProgressionItem(item, out var requiredLevel) == false)
+        {
+            message =
+                $"무기 {requiredLevel}단계를 먼저 보유해야 이 무기를 구매할 수 있습니다.";
+            return false;
+        }
+
+        if (inventory.HasEmptySlot() == false)
         {
             message = "인벤토리가 가득 찼습니다.";
             return false;

--- a/Assets/Scripts/NPC/NPCSpawner.cs
+++ b/Assets/Scripts/NPC/NPCSpawner.cs
@@ -35,7 +35,14 @@ public class NPCSpawner : MonoBehaviour
         }
         foreach (var list in m_allItems.Values)
         {
-            list.Sort((left, right) => left.Price.CompareTo(right.Price));
+            list.Sort((left, right) =>
+            {
+                var levelCompare =
+                    left.ProgressionLevel.CompareTo(right.ProgressionLevel);
+                return levelCompare != 0
+                    ? levelCompare
+                    : left.Price.CompareTo(right.Price);
+            });
         }
         var itemTypeCount = (int)ItemType.Pants - (int)ItemType.Helmet + 1;
         m_pickList = Enumerable.Range((int)ItemType.Helmet, itemTypeCount)
@@ -83,25 +90,62 @@ public class NPCSpawner : MonoBehaviour
         var maxLevel = m_inGameLoop.ExitStage;
         var curLevel = m_inGameLoop.StageLevel.Value;
         var pickList = m_pickList.OrderBy(_ => Random.value).Take(3).ToList();
+        var inventory = GetInventorySystem();
 
         foreach (var pick in pickList)
         {
             if (m_allItems.TryGetValue((ItemType)pick,out var list))
             {
-                if (list.Count == 0 || maxLevel <= 0) continue;
+                var sellableItems = GetSellableItems(pick, list, inventory);
+                if (sellableItems.Count == 0 || maxLevel <= 0) continue;
 
                 var clampedLevel = Mathf.Clamp(curLevel, 1, maxLevel);
                 var startIdx = Mathf.FloorToInt(
-                    (clampedLevel - 1) * list.Count / (float)maxLevel);
+                    (clampedLevel - 1) * sellableItems.Count / (float)maxLevel);
                 var endExclusive = Mathf.CeilToInt(
-                    clampedLevel * list.Count / (float)maxLevel);
+                    clampedLevel * sellableItems.Count / (float)maxLevel);
 
-                startIdx = Mathf.Clamp(startIdx, 0, list.Count - 1);
-                endExclusive = Mathf.Clamp(endExclusive, startIdx + 1, list.Count);
+                startIdx = Mathf.Clamp(startIdx, 0, sellableItems.Count - 1);
+                endExclusive = Mathf.Clamp(
+                    endExclusive,
+                    startIdx + 1,
+                    sellableItems.Count);
                 var pickIdx = Random.Range(startIdx, endExclusive);
-                npc.SelectItems.Add(list[pickIdx]);
+
+                npc.SelectItems.Add(sellableItems[pickIdx]);
             }
         }
+    }
+
+    private static List<InventoryItem> GetSellableItems(
+        ItemType itemType,
+        IEnumerable<InventoryItem> items,
+        InventorySystem inventory)
+    {
+        if (itemType != ItemType.Weapon)
+        {
+            return items.Where(item => item != null).ToList();
+        }
+
+        return items.Where(item =>
+            item != null &&
+            (inventory != null
+                ? inventory.CanPurchaseProgressionItem(item, out _)
+                : item.ProgressionLevel <= 1))
+            .ToList();
+    }
+
+    private InventorySystem GetInventorySystem()
+    {
+        if (m_inGameLoop?.UI == null ||
+            m_inGameLoop.UI.UIElements.TryGetValue(
+                UIState.Inventory,
+                out var element) == false)
+        {
+            return null;
+        }
+
+        return element as InventorySystem;
     }
 
     public void DestroyNPC(NPCBase ctrl)

--- a/Assets/Scripts/UI/InventoryItem.cs
+++ b/Assets/Scripts/UI/InventoryItem.cs
@@ -15,9 +15,22 @@ public class InventoryItem : CSVScriptableObject
     [CSVField(CSVFIledType.None)]
     public int Price;
     [CSVField(CSVFIledType.None)]
+    public int Level;
+    [CSVField(CSVFIledType.None)]
     public ItemType ItemType;
     public Sprite Icon;
 
     [CSVField(CSVFIledType.StatArr)]
     public StatChange[] ModifierStats;
+
+    public int ProgressionLevel
+    {
+        get
+        {
+            if (Level > 0) return Level;
+            return int.TryParse(ID, out var id) && id > 0
+                ? (id - 1) % 10 + 1
+                : 1;
+        }
+    }
 }

--- a/Assets/Scripts/UI/InventorySystem.cs
+++ b/Assets/Scripts/UI/InventorySystem.cs
@@ -185,6 +185,40 @@ public class InventorySystem : UIElementBase
         return UnequipSlots.Any(slot => slot != null && slot.SlotItem == null);
     }
 
+    public bool HasItem(ItemType itemType, int level)
+    {
+        return EnumerateOwnedItems().Any(item =>
+            item.ItemType == itemType &&
+            item.ProgressionLevel == level);
+    }
+
+    public bool CanPurchaseProgressionItem(
+        InventoryItem item,
+        out int requiredLevel)
+    {
+        requiredLevel = 0;
+        if (item == null ||
+            item.ItemType != ItemType.Weapon ||
+            item.ProgressionLevel <= 1)
+        {
+            return true;
+        }
+
+        requiredLevel = item.ProgressionLevel - 1;
+        return HasItem(ItemType.Weapon, requiredLevel);
+    }
+
+    private IEnumerable<InventoryItem> EnumerateOwnedItems()
+    {
+        var equippedSlots = EquipSlots ?? Enumerable.Empty<ItemSlot>();
+        var unequippedSlots = UnequipSlots ?? Enumerable.Empty<ItemSlot>();
+
+        return equippedSlots
+            .Concat(unequippedSlots)
+            .Where(slot => slot != null && slot.SlotItem != null)
+            .Select(slot => slot.SlotItem);
+    }
+
     private void UpdateDescription(InventoryItem item)
     {
         if (DescriptionImage ==null || DescriptionText ==null) return;


### PR DESCRIPTION
## 작업 내용
- 무기 아이템에 명시적인 진행 단계를 추가하고 기존 에셋의 ID 기반 단계 호환을 유지
- 장착 및 비장착 슬롯을 함께 검사해 이전 단계 무기 보유 여부를 판정
- NPC 상품 후보를 만들기 전에 구매 가능한 무기만 필터링해 상위 무기 노출을 차단
- 인벤토리 초기화 전에는 1단계 무기만 허용하고 구매 시점에도 진행 조건을 재검증

## 검증
- 무기 CSV와 기존 SO의 1~10단계 매핑 확인
- git diff --check 통과
- Unity Tundra 스크립트 컴파일 성공
