### PR TITLE
[Feat] Add rest area NPC rooms

### DIFF
--- a/Assets/Scripts/Enemy/BT/Actions/CustomPatrolAction.cs
+++ b/Assets/Scripts/Enemy/BT/Actions/CustomPatrolAction.cs
@@ -184,6 +184,7 @@ public partial class CustomPatrolAction : Action
             m_CurrentPatrolPoint = (m_CurrentPatrolPoint + 1) % Waypoints.Value.Count;
             var waypoint = Waypoints.Value[m_CurrentPatrolPoint];
             if (waypoint == null || waypoint.activeInHierarchy == false) continue;
+            if (ChunkManager.Instance != null && ChunkManager.Instance.IsInRestArea(waypoint.transform.position)) continue;
 
             m_CurrentTarget = waypoint.transform.position;
             if (m_NavMeshAgent != null && m_NavMeshAgent.isOnNavMesh)

--- a/Assets/Scripts/Enemy/BT/Actions/PatrolPathFinderAction.cs
+++ b/Assets/Scripts/Enemy/BT/Actions/PatrolPathFinderAction.cs
@@ -104,14 +104,21 @@ public partial class PatrolPathFinderAction : Action
 
     public GameObject CreatePatrolPoint()
     {
-        Vector3 ranPos = UnityEngine.Random.insideUnitCircle * PatrolPointDistance;
-        ranPos += Agent.Value.transform.position;
-        if (NavMesh.SamplePosition(ranPos, out NavMeshHit hit, PatrolPointDistance, NavMesh.AllAreas))
+        const int maxAttempts = 12;
+        for (var i = 0; i < maxAttempts; i++)
         {
+            Vector3 ranPos = UnityEngine.Random.insideUnitCircle * PatrolPointDistance;
+            ranPos += Agent.Value.transform.position;
+            if (NavMesh.SamplePosition(ranPos, out NavMeshHit hit, PatrolPointDistance, NavMesh.AllAreas) == false)
+                continue;
+            if (ChunkManager.Instance != null && ChunkManager.Instance.IsInRestArea(hit.position))
+                continue;
+
             var obj = m_patrolPool.GetObject();
             obj.position = hit.position;
             return obj.gameObject;
         }
+
         return null;
     }
 

--- a/Assets/Scripts/Manager/ChunkManager/Chunk.cs
+++ b/Assets/Scripts/Manager/ChunkManager/Chunk.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 public class Chunk
 {
     public Vector2Int ChunkCoord;
+    public Vector3Int BlockSize;
     public GameObject ChunkObject;
     public bool IsLoaded = false;
     public bool IsGenerate = false;
@@ -13,16 +14,25 @@ public class Chunk
     public bool IsCombineMesh = false;
     public bool IsCombiningMesh = false;
     public bool NeedsMeshRebuild = false;
+    public bool IsRestArea = false;
+    public bool HasRestAreaRoom = false;
     public HashSet<Vector2Int> CheckDirection = new HashSet<Vector2Int>();
     public List<GameObject> CombinedMeshObjects = new List<GameObject>();
     public RectInt Bounds;
     public List<Vector3> floorPosData;
+    public List<RectInt> RoomData;
+    public RectInt RestAreaRoom;
+    public Vector3 RestAreaCenter;
+    public readonly List<Vector3> RestAreaFloorPositions = new();
+    public readonly List<Vector3> RestAreaInnerFloorPositions = new();
+    public readonly List<GameObject> RestAreaLightObjects = new();
 
     public NavMeshModifier[] navMeshModifiers;
 
     public Chunk(Vector2Int coord, int size, Vector3Int blockSize, Transform parent)
     {
         ChunkCoord = coord;
+        BlockSize = blockSize;
         Bounds = new RectInt(coord.x * size * blockSize.x,
             coord.y * size * blockSize.z,
             size, size);
@@ -61,8 +71,100 @@ public class Chunk
             ChunkObject.transform,
             minRoomSize,
             blockSize,
-            result => floorPosData = result);
+            (floors, rooms) =>
+            {
+                floorPosData = floors;
+                RoomData = rooms;
+            });
         RefreshNavMeshModifiers();
+    }
+
+    public void ClearRestArea()
+    {
+        IsRestArea = false;
+        HasRestAreaRoom = false;
+        RestAreaRoom = default;
+        RestAreaCenter = default;
+        RestAreaFloorPositions.Clear();
+        RestAreaInnerFloorPositions.Clear();
+    }
+
+    public bool TrySelectRestAreaRoom(int innerPaddingCells)
+    {
+        if (RoomData == null || RoomData.Count == 0)
+        {
+            ClearRestArea();
+            return false;
+        }
+
+        RestAreaRoom = RoomData[Random.Range(0, RoomData.Count)];
+        HasRestAreaRoom = true;
+        IsRestArea = true;
+        RestAreaCenter = new Vector3(
+            Bounds.x + RestAreaRoom.center.x * BlockSize.x,
+            0f,
+            Bounds.y + RestAreaRoom.center.y * BlockSize.z);
+        RebuildRestAreaFloorCache(innerPaddingCells);
+        return true;
+    }
+
+    public bool IsWorldPositionInRestAreaRoom(Vector3 position)
+    {
+        if (IsRestArea == false || HasRestAreaRoom == false || BlockSize.x <= 0 || BlockSize.z <= 0)
+            return false;
+
+        var localX = Mathf.RoundToInt((position.x - Bounds.x) / BlockSize.x);
+        var localY = Mathf.RoundToInt((position.z - Bounds.y) / BlockSize.z);
+        return RestAreaRoom.Contains(new Vector2Int(localX, localY));
+    }
+
+    public IReadOnlyList<Vector3> GetRestAreaFloorPositions(bool preferInnerArea)
+    {
+        if (IsRestArea == false || HasRestAreaRoom == false)
+            return RestAreaFloorPositions;
+
+        if (preferInnerArea && RestAreaInnerFloorPositions.Count > 0)
+            return RestAreaInnerFloorPositions;
+
+        return RestAreaFloorPositions;
+    }
+
+    private void RebuildRestAreaFloorCache(int innerPaddingCells)
+    {
+        RestAreaFloorPositions.Clear();
+        RestAreaInnerFloorPositions.Clear();
+        if (floorPosData == null || IsRestArea == false || HasRestAreaRoom == false)
+            return;
+
+        var innerRoom = RestAreaRoom;
+        if (innerPaddingCells > 0 &&
+            RestAreaRoom.width > innerPaddingCells * 2 &&
+            RestAreaRoom.height > innerPaddingCells * 2)
+        {
+            innerRoom = new RectInt(
+                RestAreaRoom.xMin + innerPaddingCells,
+                RestAreaRoom.yMin + innerPaddingCells,
+                RestAreaRoom.width - innerPaddingCells * 2,
+                RestAreaRoom.height - innerPaddingCells * 2);
+        }
+
+        foreach (var pos in floorPosData)
+        {
+            if (IsWorldPositionInRoom(pos, RestAreaRoom))
+                RestAreaFloorPositions.Add(pos);
+            if (IsWorldPositionInRoom(pos, innerRoom))
+                RestAreaInnerFloorPositions.Add(pos);
+        }
+    }
+
+    private bool IsWorldPositionInRoom(Vector3 position, RectInt room)
+    {
+        if (BlockSize.x <= 0 || BlockSize.z <= 0)
+            return false;
+
+        var localX = Mathf.RoundToInt((position.x - Bounds.x) / BlockSize.x);
+        var localY = Mathf.RoundToInt((position.z - Bounds.y) / BlockSize.z);
+        return room.Contains(new Vector2Int(localX, localY));
     }
 
     public void RefreshNavMeshModifiers()

--- a/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
+++ b/Assets/Scripts/Manager/ChunkManager/ChunkManager.cs
@@ -16,6 +16,24 @@ public class ChunkManager : ManagerBase<ChunkManager>
     public bool IsBlockUpdateMap = false;
     [Min(1)] public int RetainedChunkPadding = 2;
 
+    [Header("Rest Area")]
+    [SerializeField, Range(0f, 1f)] private float restAreaBaseChance = 0.08f;
+    [SerializeField, Range(0f, 1f)] private float restAreaMissStackBonus = 0.04f;
+    [SerializeField, Range(0f, 1f)] private float restAreaKillWeight = 0.01f;
+    [SerializeField, Range(0f, 1f)] private float restAreaMaxChance = 0.45f;
+    [SerializeField, Min(0)] private int restAreaNpcSpawnPaddingCells = 1;
+    [SerializeField, Min(0.1f)] private float restAreaNavMeshSampleRadius = 0.45f;
+    [SerializeField, Min(1f)] private float restAreaLightSpacing = 5f;
+    [SerializeField, Min(0f)] private float restAreaLightHeight = 2.2f;
+    [SerializeField, Min(0f)] private float restAreaLightWallInset = 0.35f;
+    [SerializeField, Min(0f)] private float restAreaLightRange = 5.5f;
+    [SerializeField, Min(0f)] private float restAreaLightIntensity = 1.6f;
+    [SerializeField, Min(0)] private int restAreaMaxLightsPerRoom = 8;
+    [SerializeField, Min(0f)] private float restAreaLightActiveDistance = 40f;
+    [SerializeField, Min(0.05f)] private float restAreaLightVisibilityCheckInterval = 0.5f;
+    [SerializeField] private bool restAreaLightCastsShadows = false;
+    [SerializeField] private Color restAreaLightColor = new(1f, 0.58f, 0.28f, 1f);
+
     public Transform Player;
     public Vector3 PlayerSpawnOffset = new Vector3(0, 2, 0);
     public MapGenerator Generator;
@@ -30,7 +48,10 @@ public class ChunkManager : ManagerBase<ChunkManager>
     private bool m_isUpdatingNavMesh;
     private bool m_pendingNavMeshUpdate;
     private bool m_isNavMeshUpdateQueued;
+    private int m_restAreaMissStack;
+    private float m_nextRestAreaLightVisibilityCheckTime;
     private readonly HashSet<Chunk> m_pendingSpawnChunks = new();
+    private readonly HashSet<Chunk> m_restAreaChunks = new();
     private readonly HashSet<int> m_combinableTileLayers = new();
     private static readonly Vector2Int[] NeighborDirs =
     {
@@ -74,6 +95,8 @@ public class ChunkManager : ManagerBase<ChunkManager>
         {
             RequestMapUpdate();
         }
+
+        UpdateRestAreaLightVisibility();
     }
 
     private void RequestMapUpdate()
@@ -152,6 +175,17 @@ public class ChunkManager : ManagerBase<ChunkManager>
         if (chunk.IsGenerate == false)
         {
             yield return chunk.GenerateRoutine(MinRoomSize, BlockSize);
+            if (RollRestArea() && chunk.TrySelectRestAreaRoom(restAreaNpcSpawnPaddingCells))
+            {
+                m_restAreaChunks.Add(chunk);
+                BuildRestAreaLights(chunk);
+            }
+            else
+            {
+                m_restAreaChunks.Remove(chunk);
+                chunk.ClearRestArea();
+            }
+
             didGenerate = true;
         }
 
@@ -168,15 +202,11 @@ public class ChunkManager : ManagerBase<ChunkManager>
             RequestCombineMesh(chunk);
         }
 
-        if (didGenerate && queueSpawn == false)
+        if (didGenerate && chunk.IsGenerateMonster == false)
         {
             chunk.IsGenerateMonster = true;
-        }
-
-        if (didGenerate && queueSpawn && chunk.IsGenerateMonster == false)
-        {
-            chunk.IsGenerateMonster = true;
-            m_pendingSpawnChunks.Add(chunk);
+            if (queueSpawn || chunk.IsRestArea)
+                m_pendingSpawnChunks.Add(chunk);
         }
     }
 
@@ -216,6 +246,7 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
             ReleaseChunkContents(chunk);
             m_pendingSpawnChunks.Remove(chunk);
+            m_restAreaChunks.Remove(chunk);
             m_chunks.Remove(coord);
         }
     }
@@ -248,6 +279,14 @@ public class ChunkManager : ManagerBase<ChunkManager>
                 Destroy(filter.sharedMesh);
             }
         }
+
+        foreach (var lightObject in chunk.RestAreaLightObjects)
+        {
+            if (lightObject != null)
+                Destroy(lightObject);
+        }
+
+        chunk.RestAreaLightObjects.Clear();
 
         Generator?.ReleaseChunkTiles(chunk.ChunkObject.transform);
         Destroy(chunk.ChunkObject);
@@ -429,15 +468,169 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
             if (CanSpawnOnChunk(chunk) == false) continue;
 
-            GameLoop?.EnemySpawner?.RandomUnitSpawnPerChunk(chunk);
-            GameLoop?.NPCSpawner?.RandomUnitSpawnPerChunk(chunk);
+            if (chunk.IsRestArea)
+            {
+                GameLoop?.NPCSpawner?.RandomUnitSpawnPerChunk(chunk);
+            }
+            else
+            {
+                GameLoop?.EnemySpawner?.RandomUnitSpawnPerChunk(chunk);
+            }
+
             m_pendingSpawnChunks.Remove(chunk);
         }
     }
 
+    private bool RollRestArea()
+    {
+        var killCount = GameLoop?.KillCount != null ? GameLoop.KillCount.Value : 0;
+        var chance = restAreaBaseChance
+                     + m_restAreaMissStack * restAreaMissStackBonus
+                     + killCount * restAreaKillWeight;
+        chance = Mathf.Clamp(chance, 0f, restAreaMaxChance);
+
+        var isRestArea = Random.value < chance;
+        if (isRestArea)
+        {
+            m_restAreaMissStack = 0;
+        }
+        else
+        {
+            m_restAreaMissStack++;
+        }
+
+        return isRestArea;
+    }
+
     private bool CanSpawnOnChunk(Chunk chunk)
     {
+        if (chunk != null && chunk.IsRestArea)
+            return TryGetSpawnPointInRestArea(chunk, Vector3.up, out _);
+
         return TryGetSpawnPointOnChunk(chunk, Vector3.up, out _);
+    }
+
+    private void BuildRestAreaLights(Chunk chunk)
+    {
+        if (chunk?.ChunkObject == null || chunk.IsRestArea == false || chunk.HasRestAreaRoom == false)
+            return;
+
+        foreach (var lightObject in chunk.RestAreaLightObjects)
+        {
+            if (lightObject != null)
+                Destroy(lightObject);
+        }
+
+        chunk.RestAreaLightObjects.Clear();
+
+        var room = chunk.RestAreaRoom;
+        var parent = new GameObject("RestArea_Lights");
+        parent.transform.SetParent(chunk.ChunkObject.transform, false);
+        chunk.RestAreaLightObjects.Add(parent);
+
+        var positions = new List<Vector3>();
+        var usedCells = new HashSet<Vector2Int>();
+        AddRestAreaLightLine(chunk, positions, usedCells, room.xMin, room.xMax - 1, room.yMin, true);
+        AddRestAreaLightLine(chunk, positions, usedCells, room.xMin, room.xMax - 1, room.yMax - 1, true);
+        AddRestAreaLightLine(chunk, positions, usedCells, room.yMin, room.yMax - 1, room.xMin, false);
+        AddRestAreaLightLine(chunk, positions, usedCells, room.yMin, room.yMax - 1, room.xMax - 1, false);
+
+        var lightCount = restAreaMaxLightsPerRoom <= 0
+            ? positions.Count
+            : Mathf.Min(restAreaMaxLightsPerRoom, positions.Count);
+        for (var i = 0; i < lightCount; i++)
+        {
+            var index = lightCount == positions.Count
+                ? i
+                : Mathf.FloorToInt(i * positions.Count / (float)lightCount);
+            CreateRestAreaPointLight(parent.transform, positions[index]);
+        }
+    }
+
+    private void AddRestAreaLightLine(
+        Chunk chunk,
+        List<Vector3> positions,
+        HashSet<Vector2Int> usedCells,
+        int from,
+        int to,
+        int fixedAxis,
+        bool horizontal)
+    {
+        var blockStep = horizontal ? BlockSize.x : BlockSize.z;
+        if (blockStep <= 0) return;
+
+        var roomLength = Mathf.Max(0, to - from) * blockStep;
+        var count = Mathf.Max(1, Mathf.FloorToInt(roomLength / restAreaLightSpacing) + 1);
+        for (var i = 0; i < count; i++)
+        {
+            var t = count == 1 ? 0.5f : i / (count - 1f);
+            var movingCell = Mathf.RoundToInt(Mathf.Lerp(from, to, t));
+            var localX = horizontal ? movingCell : fixedAxis;
+            var localY = horizontal ? fixedAxis : movingCell;
+            if (usedCells.Add(new Vector2Int(localX, localY)) == false)
+                continue;
+
+            var position = new Vector3(
+                chunk.Bounds.x + localX * BlockSize.x,
+                restAreaLightHeight,
+                chunk.Bounds.y + localY * BlockSize.z);
+
+            if (horizontal)
+            {
+                var roomCenter = chunk.Bounds.y + (chunk.RestAreaRoom.center.y * BlockSize.z);
+                position.z += position.z < roomCenter ? -restAreaLightWallInset : restAreaLightWallInset;
+            }
+            else
+            {
+                var roomCenter = chunk.Bounds.x + (chunk.RestAreaRoom.center.x * BlockSize.x);
+                position.x += position.x < roomCenter ? -restAreaLightWallInset : restAreaLightWallInset;
+            }
+
+            positions.Add(position);
+        }
+    }
+
+    private void CreateRestAreaPointLight(Transform parent, Vector3 position)
+    {
+        var lightObject = new GameObject("RestArea_PointLight");
+        lightObject.transform.SetParent(parent, true);
+        lightObject.transform.position = position;
+
+        var pointLight = lightObject.AddComponent<Light>();
+        pointLight.type = LightType.Point;
+        pointLight.color = restAreaLightColor;
+        pointLight.range = restAreaLightRange;
+        pointLight.intensity = restAreaLightIntensity;
+        pointLight.shadows = restAreaLightCastsShadows ? LightShadows.Hard : LightShadows.None;
+    }
+
+    private void UpdateRestAreaLightVisibility()
+    {
+        if (Player == null || Time.time < m_nextRestAreaLightVisibilityCheckTime)
+            return;
+
+        m_nextRestAreaLightVisibilityCheckTime = Time.time + restAreaLightVisibilityCheckInterval;
+        var activeDistanceSquared = restAreaLightActiveDistance * restAreaLightActiveDistance;
+        foreach (var chunk in m_restAreaChunks)
+        {
+            if (chunk == null ||
+                chunk.IsRestArea == false ||
+                chunk.HasRestAreaRoom == false ||
+                chunk.RestAreaLightObjects.Count == 0)
+            {
+                continue;
+            }
+
+            var restCenter = chunk.RestAreaCenter;
+            restCenter.y = restAreaLightHeight;
+            var shouldEnable = restAreaLightActiveDistance <= 0f ||
+                               (Player.position - restCenter).sqrMagnitude <= activeDistanceSquared;
+            foreach (var lightObject in chunk.RestAreaLightObjects)
+            {
+                if (lightObject != null && lightObject.activeSelf != shouldEnable)
+                    lightObject.SetActive(shouldEnable);
+            }
+        }
     }
 
     private Bounds GetWorldBounds(Matrix4x4 mat, Bounds bounds)
@@ -497,8 +690,47 @@ public class ChunkManager : ManagerBase<ChunkManager>
 
     public bool TryGetSpawnPointOnChunk(Chunk chunk, Vector3 spawnOffset, out Vector3 res)
     {
+        return TryGetSpawnPoint(
+            chunk,
+            chunk?.floorPosData,
+            spawnOffset,
+            Mathf.Max(BlockSize.x, BlockSize.z) * 2f,
+            false,
+            out res);
+    }
+
+    public bool TryGetSpawnPointInRestArea(Chunk chunk, Vector3 spawnOffset, out Vector3 res)
+    {
+        return TryGetSpawnPoint(
+            chunk,
+            chunk?.GetRestAreaFloorPositions(true),
+            spawnOffset,
+            restAreaNavMeshSampleRadius,
+            true,
+            out res);
+    }
+
+    public IReadOnlyList<Vector3> GetRestAreaRoamPoints(Chunk chunk)
+    {
+        return chunk?.GetRestAreaFloorPositions(true) ?? System.Array.Empty<Vector3>();
+    }
+
+    public bool IsInRestArea(Vector3 position)
+    {
+        var chunk = GetChunk(position);
+        return chunk != null && chunk.IsWorldPositionInRestAreaRoom(position);
+    }
+
+    private bool TryGetSpawnPoint(
+        Chunk chunk,
+        IReadOnlyList<Vector3> floorPositions,
+        Vector3 spawnOffset,
+        float sampleRadius,
+        bool requireRestArea,
+        out Vector3 res)
+    {
         res = Vector3.zero;
-        if (chunk == null || chunk.floorPosData == null || chunk.floorPosData.Count == 0)
+        if (chunk == null || floorPositions == null || floorPositions.Count == 0)
         {
             return false;
         }
@@ -506,11 +738,14 @@ public class ChunkManager : ManagerBase<ChunkManager>
         const int maxAttempts = 12;
         for (var i = 0; i < maxAttempts; i++)
         {
-            var pickNum = Random.Range(0, chunk.floorPosData.Count);
-            var candidate = chunk.floorPosData[pickNum] + spawnOffset;
+            var pickNum = Random.Range(0, floorPositions.Count);
+            var candidate = floorPositions[pickNum] + spawnOffset;
 
-            if (NavMesh.SamplePosition(candidate, out var hit, Mathf.Max(BlockSize.x, BlockSize.z) * 2f, NavMesh.AllAreas))
+            if (NavMesh.SamplePosition(candidate, out var hit, sampleRadius, NavMesh.AllAreas))
             {
+                if (requireRestArea && chunk.IsWorldPositionInRestAreaRoom(hit.position) == false)
+                    continue;
+
                 res = hit.position;
                 return true;
             }

--- a/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MapGenerator.cs
@@ -59,7 +59,7 @@ public class MapGenerator : MonoBehaviour
         Transform parent,
         int minRoomSize,
         Vector3Int blockSize,
-        Action<List<Vector3>> onComplete)
+        Action<List<Vector3>, List<RectInt>> onComplete)
     {
         InitTiles();
 
@@ -72,7 +72,8 @@ public class MapGenerator : MonoBehaviour
         var root = new BSPNode(new RectInt(0, 0, width, height));
         root.Split(minRoomSize);
 
-        foreach (var room in root.GetRooms())
+        var rooms = root.GetRooms();
+        foreach (var room in rooms)
         {
             for (var x = room.xMin; x < room.xMax; x++)
             {
@@ -161,7 +162,7 @@ public class MapGenerator : MonoBehaviour
             }
         }
 
-        onComplete?.Invoke(floorPosData);
+        onComplete?.Invoke(floorPosData, rooms);
     }
 
     private Vector3 ToWorldPosition(RectInt bounds, int x, int y, Vector3Int blockSize)

--- a/Assets/Scripts/Manager/ChunkManager/MinimapFogOfWar.cs
+++ b/Assets/Scripts/Manager/ChunkManager/MinimapFogOfWar.cs
@@ -13,11 +13,14 @@ public class MinimapFogOfWar : MonoBehaviour
     {
         public Renderer Renderer;
         public bool LastEnabled;
+        public bool IsOutline;
+        public bool LastRestTint;
 
-        public MapMarker(Renderer renderer)
+        public MapMarker(Renderer renderer, bool isOutline)
         {
             Renderer = renderer;
             LastEnabled = renderer != null && renderer.enabled;
+            IsOutline = isOutline;
         }
     }
 
@@ -39,6 +42,7 @@ public class MinimapFogOfWar : MonoBehaviour
         public readonly List<FogOverlay> FogOverlays = new();
         public bool Explored;
         public bool CurrentVisible;
+        public bool RestArea;
     }
 
     private sealed class ChunkMarkerRegistration
@@ -68,6 +72,7 @@ public class MinimapFogOfWar : MonoBehaviour
     [SerializeField, Min(1f)] private float revealRadius = 12f;
     [SerializeField, Min(0.5f)] private float cellSize = 3f;
     [SerializeField] private Color fogColor = Color.black;
+    [SerializeField] private Color restAreaOutlineColor = new(1f, 0.82f, 0.1f, 1f);
     [SerializeField, Min(0f)] private float fogOverlayHeight = 2f;
     [SerializeField, Min(0.1f)] private float fogOverlayScale = 1.08f;
 
@@ -79,6 +84,7 @@ public class MinimapFogOfWar : MonoBehaviour
     private readonly List<Vector2Int> m_dirtyCells = new();
     private readonly HashSet<Renderer> m_registeredDynamicRenderers = new();
     private readonly HashSet<Renderer> m_registeredMapRenderers = new();
+    private MaterialPropertyBlock m_restAreaOutlineProperties;
     private Material m_fogMaterial;
     private Mesh m_fogMesh;
     private int m_minimapLayer = -1;
@@ -121,7 +127,7 @@ public class MinimapFogOfWar : MonoBehaviour
             if (IsBaseMapMarker(renderer) == false) continue;
 
             var cell = WorldToCell(renderer.transform.position);
-            var marker = new MapMarker(renderer);
+            var marker = new MapMarker(renderer, IsOutlineMapMarker(renderer));
             registration.Markers.Add((cell, marker));
             m_registeredMapRenderers.Add(renderer);
 
@@ -131,6 +137,7 @@ public class MinimapFogOfWar : MonoBehaviour
                 m_cells[cell] = fogCell;
             }
 
+            fogCell.RestArea = chunk.IsWorldPositionInRestAreaRoom(renderer.transform.position);
             fogCell.BaseMarkers.Add(marker);
         }
 
@@ -309,6 +316,7 @@ public class MinimapFogOfWar : MonoBehaviour
             if (marker?.Renderer == null) continue;
 
             SetMarkerEnabled(marker, true);
+            SetMarkerRestTint(marker, marker.IsOutline && cell.RestArea);
         }
 
         foreach (var overlay in cell.FogOverlays)
@@ -357,6 +365,11 @@ public class MinimapFogOfWar : MonoBehaviour
         return name.Contains("WhiteMark") || name.Contains("BlackMark") || name.Contains("GrayMark");
     }
 
+    private static bool IsOutlineMapMarker(Renderer renderer)
+    {
+        return renderer.gameObject.name.Contains("WhiteMark");
+    }
+
     private void SetMarkerEnabled(MapMarker marker, bool enabled)
     {
         if (marker.LastEnabled == enabled && marker.Renderer.enabled == enabled)
@@ -364,6 +377,15 @@ public class MinimapFogOfWar : MonoBehaviour
 
         marker.Renderer.enabled = enabled;
         marker.LastEnabled = enabled;
+    }
+
+    private void SetMarkerRestTint(MapMarker marker, bool enabled)
+    {
+        if (marker.LastRestTint == enabled)
+            return;
+
+        marker.Renderer.SetPropertyBlock(enabled ? m_restAreaOutlineProperties : null);
+        marker.LastRestTint = enabled;
     }
 
     private void SetOverlayEnabled(FogOverlay overlay, bool enabled)
@@ -404,6 +426,11 @@ public class MinimapFogOfWar : MonoBehaviour
         m_minimapLayer = LayerMask.NameToLayer("MinimapMark");
         if (m_minimapLayer < 0)
             m_minimapLayer = 0;
+
+        m_restAreaOutlineProperties ??= new MaterialPropertyBlock();
+        m_restAreaOutlineProperties.Clear();
+        m_restAreaOutlineProperties.SetColor("_BaseColor", restAreaOutlineColor);
+        m_restAreaOutlineProperties.SetColor("_Color", restAreaOutlineColor);
 
         if (m_fogMesh == null)
         {

--- a/Assets/Scripts/Manager/InGameLoop.cs
+++ b/Assets/Scripts/Manager/InGameLoop.cs
@@ -32,6 +32,7 @@ public class InGameLoop : ManagerBase<InGameLoop>
     public int ExitStage = 3;
     public int StageUpCount = 15;
     public float DeadDuration = 2f;
+    [Min(1)] public int RestAreaMaxNPCs = 2;
     [Min(1f)] public float ManagerInitializationTimeout = 30f;
     public bool IsStartGame = false;
     public PlayerController Player;

--- a/Assets/Scripts/NPC/NPCBase.cs
+++ b/Assets/Scripts/NPC/NPCBase.cs
@@ -16,6 +16,11 @@ public class NPCBase : MonoBehaviour
     public NavMeshAgent NavAgent;
     [Header("Max Count is 3")]
     public List<InventoryItem> SelectItems;
+    [Header("Rest Area Roam")]
+    [SerializeField, Min(0.5f)] private float restAreaRoamIntervalMin = 2f;
+    [SerializeField, Min(0.5f)] private float restAreaRoamIntervalMax = 5f;
+    [SerializeField, Min(0.1f)] private float restAreaRoamStoppingDistance = 0.8f;
+    [SerializeField, Min(0.1f)] private float restAreaRoamSampleRadius = 0.45f;
 
     private bool m_isTouch;
     private bool m_isInteract;
@@ -32,7 +37,10 @@ public class NPCBase : MonoBehaviour
     private NPCSpawner m_shopProvider;
     private bool m_areShopItemsAssigned;
     private readonly HashSet<Collider> m_playerColliders = new();
+    private readonly List<Vector3> m_restAreaRoamPoints = new();
     private NPCNameplate m_nameplate;
+    private bool m_canRestAreaRoam;
+    private float m_nextRestAreaRoamTime;
 
     private void Awake()
     {
@@ -78,6 +86,8 @@ public class NPCBase : MonoBehaviour
         m_isTouch = false;
         m_player = null;
         m_playerColliders.Clear();
+        m_restAreaRoamPoints.Clear();
+        m_canRestAreaRoam = false;
     }
 
     private void OnTriggerEnter(Collider other)
@@ -94,16 +104,20 @@ public class NPCBase : MonoBehaviour
 
     private void Update()
     {
-        if (m_isTouch == false) return;
-        var interactAction = m_player?.input?.currentActionMap?.FindAction("Interact");
-        if (interactAction != null && interactAction.triggered)
+        if (m_isTouch)
         {
-            var target = m_player.transform.position;
-            target.y = transform.position.y;
-            transform.LookAt(target, Vector3.up);
-            if (m_isInteract) Interact();
-            else StartInteract();
+            var interactAction = m_player?.input?.currentActionMap?.FindAction("Interact");
+            if (interactAction != null && interactAction.triggered)
+            {
+                var target = m_player.transform.position;
+                target.y = transform.position.y;
+                transform.LookAt(target, Vector3.up);
+                if (m_isInteract) Interact();
+                else StartInteract();
+            }
         }
+
+        UpdateRestAreaRoam();
     }
 
     private void OnTriggerExit(Collider other)
@@ -152,6 +166,55 @@ public class NPCBase : MonoBehaviour
         m_areShopItemsAssigned = false;
         SelectItems ??= new List<InventoryItem>();
         SelectItems.Clear();
+    }
+
+    public void ConfigureRestAreaRoam(IReadOnlyList<Vector3> roamPoints)
+    {
+        m_restAreaRoamPoints.Clear();
+        if (roamPoints != null)
+        {
+            for (var i = 0; i < roamPoints.Count; i++)
+                m_restAreaRoamPoints.Add(roamPoints[i]);
+        }
+
+        m_canRestAreaRoam = NavAgent != null && m_restAreaRoamPoints.Count > 1;
+        if (m_canRestAreaRoam == false) return;
+
+        NavAgent.enabled = true;
+        NavAgent.stoppingDistance = restAreaRoamStoppingDistance;
+        if (NavMesh.SamplePosition(transform.position, out var hit, restAreaRoamSampleRadius, NavMesh.AllAreas) &&
+            IsValidRestAreaPoint(hit.position))
+        {
+            NavAgent.Warp(hit.position);
+        }
+
+        m_nextRestAreaRoamTime = Time.time + Random.Range(0.5f, restAreaRoamIntervalMax);
+    }
+
+    private void UpdateRestAreaRoam()
+    {
+        if (m_canRestAreaRoam == false || m_isInteract || NavAgent == null || NavAgent.enabled == false)
+            return;
+        if (Time.time < m_nextRestAreaRoamTime)
+            return;
+        if (NavAgent.isOnNavMesh == false)
+            return;
+        if (NavAgent.pathPending || NavAgent.remainingDistance > NavAgent.stoppingDistance)
+            return;
+
+        var target = m_restAreaRoamPoints[Random.Range(0, m_restAreaRoamPoints.Count)];
+        if (NavMesh.SamplePosition(target, out var hit, restAreaRoamSampleRadius, NavMesh.AllAreas) &&
+            IsValidRestAreaPoint(hit.position))
+        {
+            NavAgent.SetDestination(hit.position);
+        }
+
+        m_nextRestAreaRoamTime = Time.time + Random.Range(restAreaRoamIntervalMin, restAreaRoamIntervalMax);
+    }
+
+    private bool IsValidRestAreaPoint(Vector3 position)
+    {
+        return ChunkManager.Instance == null || ChunkManager.Instance.IsInRestArea(position);
     }
 
     private void EnsureShopItemsAssigned()

--- a/Assets/Scripts/NPC/NPCSpawner.cs
+++ b/Assets/Scripts/NPC/NPCSpawner.cs
@@ -64,11 +64,15 @@ public class NPCSpawner : MonoBehaviour
 
     public void RandomUnitSpawnPerChunk(Chunk chunk)
     {
-        for (var i = 0; i < UnitCountPerChunk; i++)
+        if (chunk == null || chunk.IsRestArea == false) return;
+
+        var maxCount = Mathf.Max(1, m_inGameLoop != null ? m_inGameLoop.RestAreaMaxNPCs : UnitCountPerChunk);
+        var spawnCount = Random.Range(1, maxCount + 1);
+        for (var i = 0; i < spawnCount; i++)
         {
             if (ChunkManager.Instance == null || m_inGameLoop == null) break;
             Vector3 pos = Vector3.zero;
-            var res = ChunkManager.Instance.TryGetSpawnPointOnChunk(chunk, Vector3.up, out pos);
+            var res = ChunkManager.Instance.TryGetSpawnPointInRestArea(chunk, Vector3.up, out pos);
             if (res == false) continue;
 
             var keyValue = m_allNPCs.ElementAt(Random.Range(0, m_allNPCs.Keys.Count));
@@ -79,6 +83,7 @@ public class NPCSpawner : MonoBehaviour
             trans.rotation = Quaternion.identity;
             npc.PrepareShop(this);
             npc.gameObject.SetActive(true);
+            npc.ConfigureRestAreaRoam(ChunkManager.Instance.GetRestAreaRoamPoints(chunk));
             MinimapFogOfWar.Instance?.RegisterDynamicMarkerRoot(npc.transform, MinimapFogOfWar.DynamicMarkerKind.Entity);
             npc.ChunkRefresh();
         }


### PR DESCRIPTION
## Summary
- Add rest area room selection per generated chunk.
- Spawn and roam NPCs only inside rest area rooms.
- Mark rest areas on the minimap and add distance-gated room lighting.
- Prevent enemy patrol waypoints from targeting rest areas.

## Validation
- dotnet build Assembly-CSharp.csproj